### PR TITLE
Add macOS (Apple Silicon) desktop build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,99 @@
+name: macOS Build
+
+# Builds a native macOS (Apple Silicon / arm64) build with OpenCASCADE + SDL2
+# from Homebrew, packages a self-contained Materializr.app into a .dmg via
+# packaging/macos/build-dmg.sh, and uploads it as a workflow artifact. On a
+# published GitHub Release it also attaches the .dmg. The Linux/Windows/Android
+# builds are unaffected.
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'android/**'
+      - 'scripts/**'
+      - '.github/workflows/linux.yml'
+      - '.github/workflows/windows.yml'
+  workflow_dispatch:
+  release:
+    types: [ published ]
+
+# A newer push on main cancels an in-flight build — older runs wouldn't ship.
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    name: macOS (arm64)
+    # macos-14 (and -15) are Apple Silicon runners; this build is arm64-only.
+    runs-on: macos-14
+
+    # contents: write lets softprops/action-gh-release attach the .dmg to a
+    # published Release (matches linux.yml / windows.yml).
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # cmake is preinstalled on the runner; bring the rest from Homebrew. GLM
+      # and Dear ImGui are fetched by CMake, so they're not listed here.
+      - name: Install dependencies
+        run: brew install opencascade sdl2 dylibbundler
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(brew --prefix)"
+
+      - name: Build
+        run: cmake --build build -j$(sysctl -n hw.ncpu)
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Package .app + .dmg
+        run: ./packaging/macos/build-dmg.sh
+
+      # Mount the .dmg and actually launch the bundled app — the only thing that
+      # proves the dylib bundling + rpath rewrites are correct (a green build that
+      # only `ls`-es the file can still ship a bundle that doesn't load). A dyld
+      # failure aborts before main; reaching GL init proves every dylib resolved.
+      # Run from / so it can't find resources via the repo working directory.
+      - name: Smoke-test the packaged bundle
+        run: |
+          set -uo pipefail
+          DMG=$(ls build/Materializr-*-arm64.dmg)
+          echo "Testing $DMG"; ls -lh "$DMG"
+          hdiutil attach "$DMG" -mountpoint /Volumes/MZ -nobrowse -quiet
+          ( cd / && /Volumes/MZ/Materializr.app/Contents/MacOS/materializr ) > /tmp/launch.log 2>&1 &
+          APP_PID=$!
+          for i in $(seq 1 25); do
+            grep -qiE "^GL |Loaded font|dyld|Library not loaded|Failed to (create|init)" /tmp/launch.log && break
+            sleep 1
+          done
+          kill "$APP_PID" 2>/dev/null || true
+          hdiutil detach /Volumes/MZ -quiet || true
+          echo "---- launch log ----"; cat /tmp/launch.log || true
+          if grep -qiE "dyld|Library not loaded|duplicate LC_RPATH|image not found|symbol not found" /tmp/launch.log; then
+            echo "FAIL: dynamic loader error — the bundle is not self-contained"; exit 1
+          elif grep -qiE "^GL |Loaded font" /tmp/launch.log; then
+            echo "PASS: bundle launched and reached GL init"
+          elif grep -qiE "SDL|window|display" /tmp/launch.log; then
+            echo "PASS: all dylibs resolved (runner had no display; stopped at window creation)"
+          else
+            echo "FAIL: app produced no output — possible silent load failure"; exit 1
+          fi
+
+      - name: Upload .dmg artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Materializr-macos-arm64
+          path: build/Materializr-*-arm64.dmg
+
+      - name: Attach to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/Materializr-*-arm64.dmg

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,6 @@
 # Building Materializr
 
-One repo, three targets. The windowing/input backend is SDL2 on every platform;
+One repo, four targets. The windowing/input backend is SDL2 on every platform;
 the touch interface is a **runtime setting** (Settings ▸ General ▸ Touch mode,
 default on for Android, off on desktop) — not a separate build.
 
@@ -28,6 +28,40 @@ The release AppImage is built in Docker: `./scripts/build-appimage.sh`
 CI (`.github/workflows/windows.yml`) is the reference: vcpkg provides
 `opencascade glew curl sdl2` (x64-windows), then a standard CMake/MSVC build
 with `-DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake`.
+
+## macOS (Apple Silicon)
+
+```sh
+brew install cmake opencascade sdl2
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(brew --prefix)"
+cmake --build build -j$(sysctl -n hw.ncpu)
+./build/materializr
+```
+
+Needs the Xcode Command Line Tools (`xcode-select --install`) for AppleClang.
+GLM and Dear ImGui are fetched by CMake; OpenCASCADE and SDL2 come from Homebrew,
+and curl + zlib from the macOS SDK. The GL backend uses the system OpenGL
+framework (`<OpenGL/gl3.h>`) — no GLEW loader — with a forward-compatible **3.3
+Core** context running the same GLSL 330 shaders as the other desktop targets.
+
+Tested on arm64 (Apple Silicon), including HiDPI/Retina — the offscreen 3D
+viewport renders at the display's pixel resolution.
+
+A self-contained `Materializr.app` + `.dmg` is built by
+`./packaging/macos/build-dmg.sh` (run after the build above; needs
+`brew install dylibbundler`). It copies every Homebrew/OpenCASCADE dylib into
+the bundle and rewrites install names, so the app runs on a Mac that has never
+seen Homebrew. It is ad-hoc signed (not notarized): a downloaded copy is
+quarantined, so the first launch needs **System Settings ▸ Privacy & Security ▸
+"Open Anyway"** (macOS 15 removed the old right-click ▸ Open bypass), or
+`xattr -dr com.apple.quarantine Materializr.app`.
+
+The bundled Homebrew dylibs are built for the macOS they were compiled on, so a
+locally built `.dmg` requires that macOS or newer — the script writes the true
+floor into `LSMinimumSystemVersion`. CI builds on the `macos-14` runner, so the
+released `.dmg` targets **macOS 14+**; it is built, the bundle is launch-tested,
+and the artifact uploaded on pushes to `main` (`.github/workflows/macos.yml`).
+Not yet wired up: Intel/universal binaries and Developer-ID signing/notarization.
 
 ## Android (arm64-v8a)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.20)
 project(Materializr VERSION 1.2.7 LANGUAGES CXX)
 
+# macOS: deliberately do NOT pin CMAKE_OSX_DEPLOYMENT_TARGET. The bundled Homebrew
+# OpenCASCADE/SDL2 dylibs are built for the build host's macOS, so they — not our
+# compile flag — set the real floor of a packaged .dmg. Letting the binary inherit
+# the host target keeps it consistent with those dylibs (no "built for newer
+# version" linker warnings), and packaging/macos/build-dmg.sh derives the true
+# LSMinimumSystemVersion from the actual binaries so the plist can't lie. (Override
+# with -DCMAKE_OSX_DEPLOYMENT_TARGET=… only alongside dylibs built for that target.)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -73,10 +81,12 @@ target_link_libraries(imgui_lib PUBLIC ${MZ_SDL2_TARGET})
 find_package(OpenGL REQUIRED)
 
 # OpenCASCADE
-if(WIN32)
-    # Windows: OpenCASCADE is provided by vcpkg (see vcpkg.json). Its CMake config
-    # exports the same TK* targets and sets OpenCASCADE_INCLUDE_DIR, so the rest
-    # of this file is identical to the Linux path.
+if(WIN32 OR APPLE)
+    # Windows (vcpkg) and macOS (Homebrew: `brew install opencascade`) both ship a
+    # clean OpenCASCADE CMake config that exports the TK* targets and sets
+    # OpenCASCADE_INCLUDE_DIR directly — no path patching needed (unlike the Debian
+    # packages handled in the else branch). The Homebrew config lives under the brew
+    # prefix; pass -DCMAKE_PREFIX_PATH="$(brew --prefix)" if CMake doesn't find it.
     find_package(OpenCASCADE CONFIG REQUIRED)
 else()
 # Linux: work around missing libtbb-dev symlinks by patching cmake files locally.
@@ -291,9 +301,13 @@ if(WIN32)
     message(STATUS "OpenCASCADE libraries: ${OpenCASCADE_LIBRARIES}")
     target_link_libraries(materializr PRIVATE ${OpenCASCADE_LIBRARIES})
 else()
-    # OCCT 7.8 renamed the data-exchange toolkits (TKSTEP -> TKDESTEP, etc.).
-    # Pick names by version so we link on both pre- and post-refactor system
-    # OCCT (Linux distros are now shipping 7.9+).
+    # Linux (system OCCT) and macOS (Homebrew) link the explicit set of toolkits
+    # the app actually uses. This is deliberately NOT OCCT's umbrella
+    # ${OpenCASCADE_LIBRARIES}: that pulls in the Draw/test harnesses (TKDraw,
+    # TKViewerTest, TKQADraw, ...), which the app never calls and which bloat the
+    # bundled macOS .dmg with ~dozens of extra dylibs. OCCT 7.8 renamed the
+    # data-exchange toolkits (TKSTEP -> TKDESTEP, etc.); pick names by version so
+    # we link on both pre- and post-refactor OCCT (distros + Homebrew ship 7.9+).
     if(OpenCASCADE_VERSION VERSION_GREATER_EQUAL 7.8)
         set(OCCT_DATAEXCHANGE_LIBS TKDESTEP TKDEIGES TKDESTL)
     else()
@@ -345,6 +359,15 @@ if(MSVC)
     target_compile_definitions(materializr PRIVATE
         _USE_MATH_DEFINES NOMINMAX WIN32_LEAN_AND_MEAN)
     target_compile_options(materializr PRIVATE /bigobj)
+endif()
+
+if(APPLE)
+    # OpenGL was deprecated on macOS 10.14; silence the framework headers app-wide.
+    # gl_common.h also defines this, but ImGui's GL3 backend pulls <OpenGL/gl3.h>
+    # in on its own, so define it on both targets. Apple still ships/supports the
+    # framework, and there's no Metal/MoltenVK port yet.
+    target_compile_definitions(materializr PRIVATE GL_SILENCE_DEPRECATION)
+    target_compile_definitions(imgui_lib PRIVATE GL_SILENCE_DEPRECATION)
 endif()
 
 # Surface the project version to the C++ code so About / update-checker can use

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Build Materializr.app and a distributable .dmg on macOS (Apple Silicon).
+#
+# Prereqs:
+#   - a Release build in $BUILD_DIR (default: build/) — see BUILD.md (macOS)
+#   - brew install dylibbundler
+#
+# The result is self-contained: every Homebrew/OpenCASCADE dylib the binary
+# needs is copied into the .app and its install name rewritten, so the app runs
+# on a Mac that has never seen Homebrew. It is ad-hoc signed (not notarized): a
+# downloaded copy is quarantined, so the first launch needs
+#   System Settings > Privacy & Security > "Open Anyway"
+# (the old right-click > Open Gatekeeper bypass was removed in macOS 15), or
+#   xattr -dr com.apple.quarantine Materializr.app
+#
+# NOTE: the bundled Homebrew dylibs are built for the host's macOS, so the .dmg's
+# real minimum is the macOS it was built on. This script writes that true floor
+# into LSMinimumSystemVersion (derived from the binaries) rather than guessing.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+BUILD_DIR="${BUILD_DIR:-build}"
+BIN="$BUILD_DIR/materializr"
+APP="$BUILD_DIR/Materializr.app"
+VERSION="$(grep -m1 'project(Materializr VERSION' CMakeLists.txt | sed -E 's/.*VERSION ([0-9.]+).*/\1/')"
+DMG="$BUILD_DIR/Materializr-${VERSION}-arm64.dmg"
+BREW="$(brew --prefix)"
+
+[ -x "$BIN" ] || { echo "error: $BIN not found — build first: cmake --build $BUILD_DIR"; exit 1; }
+[ -n "$VERSION" ] || { echo "error: could not parse version from CMakeLists.txt"; exit 1; }
+command -v dylibbundler >/dev/null || { echo "error: dylibbundler not found — brew install dylibbundler"; exit 1; }
+
+# One scratch dir for the iconset + dmg staging, cleaned up on any exit.
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> Assembling $APP (v$VERSION)"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources/assets" "$APP/Contents/Frameworks"
+
+cp "$BIN" "$APP/Contents/MacOS/materializr"
+
+# Bundled fonts — resolveBundledFont() looks in <exe>/../Resources/assets/fonts.
+cp -R assets/fonts "$APP/Contents/Resources/assets/"
+
+# Icon: icon.png -> Materializr.icns (build a full iconset so Finder/Dock scale).
+ICONSET="$WORK/Materializr.iconset"
+mkdir -p "$ICONSET"
+for s in 16 32 128 256 512; do
+  sips -z "$s"        "$s"        icon.png --out "$ICONSET/icon_${s}x${s}.png"    >/dev/null
+  sips -z "$((s*2))"  "$((s*2))"  icon.png --out "$ICONSET/icon_${s}x${s}@2x.png" >/dev/null
+done
+iconutil -c icns "$ICONSET" -o "$APP/Contents/Resources/Materializr.icns"
+
+# Copy every non-system dylib into Frameworks/ and rewrite install names to
+# @executable_path/../Frameworks. Search paths cover the Homebrew + OCCT kegs so
+# dylibbundler never needs to prompt interactively.
+echo "==> Bundling dylibs"
+dylibbundler -b -cd -of \
+  -x "$APP/Contents/MacOS/materializr" \
+  -d "$APP/Contents/Frameworks/" \
+  -p "@executable_path/../Frameworks/" \
+  -s "$BREW/lib" \
+  -s "$BREW/opt/opencascade/lib" </dev/null
+
+# dylibbundler rewrites each original rpath to the same @executable_path/../
+# Frameworks, leaving duplicate LC_RPATH entries that dyld refuses to load
+# ("duplicate LC_RPATH"). This happens in the main binary AND in any bundled OCCT
+# dylib that shipped with more than one rpath, so collapse duplicates everywhere.
+# -delete_rpath removes one matching entry per call.
+RP='@executable_path/../Frameworks/'
+dedupe_rpath() {
+  while [ "$(otool -l "$1" | grep -c "path $RP")" -gt 1 ]; do
+    install_name_tool -delete_rpath "$RP" "$1"
+  done
+}
+dedupe_rpath "$APP/Contents/MacOS/materializr"
+for dylib in "$APP/Contents/Frameworks/"*.dylib; do
+  dedupe_rpath "$dylib"
+done
+
+# Effective minimum macOS = the highest LC_BUILD_VERSION 'minos' across the main
+# binary and every bundled dylib — a load fails if the OS is older than ANY of
+# them. Homebrew bottles are built for the host's macOS, so this reports what the
+# .dmg actually requires instead of a fictional floor. Falls back to 11.0 only if
+# nothing carries a build-version load command (very old toolchains).
+minos_of() { otool -l "$1" | awk '/LC_BUILD_VERSION/{v=1} v&&/minos/{print $2; v=0}'; }
+MINOS="$(minos_of "$APP/Contents/MacOS/materializr")"
+for dylib in "$APP/Contents/Frameworks/"*.dylib; do
+  m="$(minos_of "$dylib")" || true
+  [ -n "$m" ] || continue
+  if [ "$(printf '%s\n%s\n' "${MINOS:-0}" "$m" | sort -V | tail -1)" = "$m" ]; then MINOS="$m"; fi
+done
+: "${MINOS:=11.0}"
+echo "==> Bundle minimum macOS: $MINOS"
+
+cat > "$APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key><string>Materializr</string>
+  <key>CFBundleDisplayName</key><string>Materializr</string>
+  <key>CFBundleExecutable</key><string>materializr</string>
+  <key>CFBundleIdentifier</key><string>com.materializr.app</string>
+  <key>CFBundleVersion</key><string>${VERSION}</string>
+  <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleIconFile</key><string>Materializr</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>LSMinimumSystemVersion</key><string>${MINOS}</string>
+  <key>LSApplicationCategoryType</key><string>public.app-category.graphics-design</string>
+  <key>NSHighResolutionCapable</key><true/>
+  <key>NSHumanReadableCopyright</key><string>Materializr contributors — GNU GPL v3.</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeName</key><string>Materializr Project</string>
+      <key>CFBundleTypeExtensions</key><array><string>materializr</string></array>
+      <key>CFBundleTypeRole</key><string>Editor</string>
+      <key>LSHandlerRank</key><string>Owner</string>
+    </dict>
+  </array>
+</dict>
+</plist>
+PLIST
+
+# Ad-hoc sign inside-out: every nested dylib first, then the bundle. Apple
+# deprecated --deep and signs nested code in an unspecified order with it; signing
+# leaf-first is the supported way. Not notarized — see the header note.
+echo "==> Ad-hoc signing"
+find "$APP/Contents/Frameworks" -name '*.dylib' -exec codesign --force --sign - {} +
+codesign --force --sign - "$APP"
+# Gate on verification — on its own line so `set -e` aborts a broken seal. (The
+# previous `... && echo OK` form let a failed verify slide straight into shipping,
+# because the left side of && is exempt from errexit.)
+codesign --verify --strict --verbose=2 "$APP"
+echo "    signature OK"
+
+# .dmg with an /Applications symlink for drag-to-install.
+echo "==> Building $DMG"
+STAGE="$WORK/dmg"
+mkdir -p "$STAGE"
+cp -R "$APP" "$STAGE/"
+ln -s /Applications "$STAGE/Applications"
+rm -f "$DMG"
+hdiutil create -volname "Materializr ${VERSION}" -srcfolder "$STAGE" \
+  -ov -format UDZO "$DMG" >/dev/null
+
+echo "==> Done"
+echo "    $APP"
+echo "    $DMG  ($(du -h "$DMG" | cut -f1))"

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -142,6 +142,8 @@ namespace materializr { namespace force_link { void linkAll(); } }
 #include <cstdio>
 #ifdef _WIN32
 #include <windows.h> // GetModuleFileNameA for exe dir (font path lookup)
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h> // _NSGetExecutablePath for exe dir (no /proc on macOS)
 #else
 #include <unistd.h>  // readlink for resolving /proc/self/exe → exe dir (font path lookup)
 #endif
@@ -416,9 +418,10 @@ static const char* computeImguiIniPath() {
 
 // Resolve a TTF shipped in assets/fonts against the layouts we run from:
 //   1. <exe>/../share/materializr/fonts/  (AppImage)
-//   2. <exe>/../assets/fonts/             (dev: binary in build/)
-//   3. <exe>/assets/fonts/                (Windows portable zip: assets next to exe)
-//   4. <cwd>/assets/fonts/                (dev: launched from repo root)
+//   2. <exe>/../Resources/assets/fonts/   (macOS .app bundle)
+//   3. <exe>/../assets/fonts/             (dev: binary in build/)
+//   4. <exe>/assets/fonts/                (Windows portable zip: assets next to exe)
+//   5. <cwd>/assets/fonts/                (dev: launched from repo root)
 // Returns "" when the font isn't found anywhere — callers degrade gracefully.
 std::string Application::resolveBundledFont(const std::string& fname) const {
     char exePath[4096];
@@ -429,6 +432,15 @@ std::string Application::resolveBundledFont(const std::string& fname) const {
         exePath[n] = '\0';
         std::string p(exePath);
         auto slash = p.find_last_of("\\/");
+        if (slash != std::string::npos) exeDir = p.substr(0, slash);
+    }
+#elif defined(__APPLE__)
+    // No /proc on macOS — ask dyld for the executable path. The buffer is sized
+    // generously; _NSGetExecutablePath fills it and NUL-terminates on success.
+    uint32_t n = sizeof(exePath);
+    if (_NSGetExecutablePath(exePath, &n) == 0) {
+        std::string p(exePath);
+        auto slash = p.find_last_of('/');
         if (slash != std::string::npos) exeDir = p.substr(0, slash);
     }
 #else
@@ -442,6 +454,7 @@ std::string Application::resolveBundledFont(const std::string& fname) const {
 #endif
     const std::string candidates[] = {
         exeDir + "/../share/materializr/fonts/" + fname,
+        exeDir + "/../Resources/assets/fonts/" + fname,
         exeDir + "/../assets/fonts/" + fname,
         exeDir + "/assets/fonts/" + fname,
         "assets/fonts/" + fname,
@@ -526,13 +539,10 @@ void Application::initImGui() {
     }
 
     // Swap ImGui's default ProggyClean for JetBrains Mono — slashed zero,
-    // distinct 0/8/B/6, designed for engineering UIs. Resolved from a small
-    // list of candidate paths so both AppImage and dev builds find it:
-    //   1. <exe>/../share/materializr/fonts/    (AppImage layout)
-    //   2. <exe>/../assets/fonts/               (dev: binary in build/)
-    //   3. <cwd>/assets/fonts/                  (dev: launched from repo root)
-    // Falls through to the bundled default if the TTF isn't present, so
-    // a font miss never bricks the UI.
+    // distinct 0/8/B/6, designed for engineering UIs. resolveBundledFont() tries
+    // the AppImage, macOS .app Resources/, dev-build, and cwd layouts (see its
+    // candidate list). Falls through to the bundled default if the TTF isn't
+    // present, so a font miss never bricks the UI.
     {
         std::string path = resolveBundledFont("JetBrainsMono-Regular.ttf");
         if (!path.empty()) {

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -134,7 +134,25 @@ void Application::renderViewport() {
     int h = static_cast<int>(contentSize.y);
 
     if (w > 0 && h > 0) {
-        m_viewport->resize(w, h);
+        // Render the offscreen 3D viewport at the display's PIXEL resolution, not
+        // logical points, so it stays crisp on HiDPI/Retina screens. Otherwise the
+        // FBO is point-sized and ImGui::Image upscales it — soft/blurry at 2x. Only
+        // the render target scales: the image is still laid out at contentSize
+        // (points) and picking works in point-space (mouse + viewport both points
+        // → NDC), so neither needs to change. DisplayFramebufferScale is (1,1) on
+        // non-HiDPI displays, making this a no-op there; it's re-read every frame,
+        // so dragging the window between monitors of different density adapts live.
+        // Cap the scale at 2x. Retina is 2.0, and the FBO's color + depth/stencil
+        // + MSAA buffers (all rebuilt on every resize) cost ~quadratically in it,
+        // so a display reporting >2x would burn memory for no visible gain. macOS
+        // backing scale is only ever 1 or 2, so this clamp is a safety bound, not
+        // a behaviour change there.
+        const ImGuiIO& io = ImGui::GetIO();
+        const float fbScaleX = std::min(io.DisplayFramebufferScale.x, 2.0f);
+        const float fbScaleY = std::min(io.DisplayFramebufferScale.y, 2.0f);
+        const int fbw = static_cast<int>(contentSize.x * fbScaleX);
+        const int fbh = static_cast<int>(contentSize.y * fbScaleY);
+        m_viewport->resize(fbw, fbh);
 
         bool geomChanged = m_meshesDirty || !m_dirtyBodyIds.empty();
         if (geomChanged) {

--- a/src/app/Window.cpp
+++ b/src/app/Window.cpp
@@ -43,6 +43,15 @@ Window::Window(int width, int height, const std::string& title)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+#if defined(__APPLE__)
+    // macOS only grants a 3.2+ context to a forward-compatible CORE profile;
+    // without this flag the request silently falls back to legacy GL 2.1, which
+    // can't compile the GLSL 330 shaders. (Forward-compatible drops removed-in-
+    // core legacy entry points — none of which this renderer uses.) This is the
+    // only writer of SDL_GL_CONTEXT_FLAGS; if a debug-context flag is ever added,
+    // OR it in rather than overwrite.
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
+#endif
 #endif
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
@@ -80,6 +89,18 @@ Window::Window(int width, int height, const std::string& title)
         throw std::runtime_error("Failed to initialize GLEW (OpenGL loader)");
     }
 #endif
+
+    // Log the context we actually got. The 3.3-core request can be silently
+    // downgraded (notably on macOS without the forward-compatible flag → GL 2.1,
+    // where the GLSL 330 shaders won't compile); surfacing the version here turns
+    // that from a mystery black screen into a one-line diagnostic.
+    {
+        const char* ver = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+        const char* glsl = reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
+        const char* rend = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+        std::cout << "GL " << (ver ? ver : "?") << " | GLSL " << (glsl ? glsl : "?")
+                  << " | " << (rend ? rend : "?") << std::endl;
+    }
 
     SDL_GL_SetSwapInterval(1); // vsync
 

--- a/src/gl_common.h
+++ b/src/gl_common.h
@@ -28,6 +28,19 @@ void glShaderSourceAdapt(GLuint shader, GLsizei count,
 // points with GLEW (provided by vcpkg). glewInit() runs once after the context
 // is current — see Window.cpp. GLEW must precede any other GL header.
 #include <GL/glew.h>
+#elif defined(__APPLE__)
+// macOS: OpenGL.framework exports the 3.2+ core-profile entry points directly
+// via <OpenGL/gl3.h> (up to GL 4.1 — the platform ceiling, which still covers
+// every GLSL 330 shader here), so no GLEW-style loader is needed. The context
+// must be created with the forward-compatible core profile — see Window.cpp.
+// GL was deprecated on macOS 10.14; silence those headers (Apple still ships
+// and supports the framework, and there's no Metal/MoltenVK port yet). The
+// CMake build also defines this for ImGui's GL backend, so guard against the
+// redefinition for translation units that get both.
+#ifndef GL_SILENCE_DEPRECATION
+#define GL_SILENCE_DEPRECATION
+#endif
+#include <OpenGL/gl3.h>
 #else
 // Linux desktop with Mesa: GL_GLEXT_PROTOTYPES gives direct access to GL 3.3+.
 #define GL_GLEXT_PROTOTYPES

--- a/src/viewport/Viewport.cpp
+++ b/src/viewport/Viewport.cpp
@@ -73,36 +73,6 @@ void Viewport::setSamples(int samples)
     createFramebuffer();
 }
 
-void Viewport::renderImGuiWindow()
-{
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
-    ImGui::Begin("Viewport");
-
-    // Check if the viewport content area has changed size
-    ImVec2 contentSize = ImGui::GetContentRegionAvail();
-    int newWidth = static_cast<int>(contentSize.x);
-    int newHeight = static_cast<int>(contentSize.y);
-
-    if (newWidth > 0 && newHeight > 0) {
-        resize(newWidth, newHeight);
-    }
-
-    // Display the FBO color texture
-    ImGui::Image(
-        static_cast<ImTextureID>(m_colorTexture),
-        contentSize,
-        ImVec2(0, 1), // UV0: flip Y for OpenGL
-        ImVec2(1, 0)  // UV1
-    );
-
-    // Handle mouse input when hovered
-    m_isHovered = ImGui::IsItemHovered();
-    handleInput();
-
-    ImGui::End();
-    ImGui::PopStyleVar();
-}
-
 void Viewport::handleInput()
 {
     if (!m_isHovered) {

--- a/src/viewport/Viewport.h
+++ b/src/viewport/Viewport.h
@@ -36,9 +36,6 @@ public:
     int getWidth() const { return m_width; }
     int getHeight() const { return m_height; }
 
-    /// Render the viewport as an ImGui window. Handles mouse input.
-    void renderImGuiWindow();
-
     /// Access the camera.
     Camera& getCamera() { return m_camera; }
     const Camera& getCamera() const { return m_camera; }


### PR DESCRIPTION
## What this does

Adds a native arm64 **macOS (Apple Silicon)** desktop build from the shared `src/` — the fourth target alongside Linux, Windows, and Android. All platform-specific code is guarded so the other three builds are unchanged.

- GL backend on the system OpenGL framework (`<OpenGL/gl3.h>`, no GLEW loader) with a forward-compatible 3.3 Core context, plus a one-time GL/GLSL/renderer log so a silent context downgrade is a one-line diagnostic.
- HiDPI/Retina: the offscreen 3D viewport renders at the display's pixel resolution (clamped at 2×); picking is unchanged (works in point-space).
- macOS font/resource resolution via `_NSGetExecutablePath` + a bundle `Resources` path (the previous `/proc/self/exe` lookup doesn't exist on macOS).
- CMake `APPLE` branch: Homebrew OpenCASCADE clean config (no Debian `.so` patching), explicit "slim" toolkit link (no Draw/test harnesses).
- `packaging/macos/build-dmg.sh`: a self-contained, dylibbundler-bundled, ad-hoc-signed `Materializr.app` + `.dmg`; `LSMinimumSystemVersion` derived from the actual binaries.
- `.github/workflows/macos.yml`: build, test, a mount-and-launch smoke test, and `.dmg` artifact upload on the `macos-14` runner.

## How it was tested

Built on Apple M4 (macOS 26.5) and on the `macos-14` CI runner. Re-verified on the current tree: `cmake -B build -DCMAKE_BUILD_TYPE=Release` + `cmake --build build` (arm64) succeeds and `ctest` passes **7/7**.

## Checklist

- [x] Builds on desktop and tests pass — macOS arm64, `ctest` 7/7
- [x] Doesn't touch Android; Linux/Windows behavior unchanged (additive `APPLE`-only branch)
- [x] n/a — platform build support, not a new user-facing feature/plugin
- [x] n/a — no touch-specific behavior added
- [x] Code matches the style of the surrounding files

<!-- By submitting, I agree this contribution is licensed under GPL-3.0-or-later. -->
