### PR TITLE
Security hardening: untrusted-file parsers + update flow

### DIFF
--- a/src/app/Application_Dialogs.cpp
+++ b/src/app/Application_Dialogs.cpp
@@ -2,6 +2,7 @@
 #include "ui_scale.h"
 #include "touch_mode.h"
 #include "gl_common.h"
+#include "url_open.h"
 
 #include <cstdlib>
 #include <filesystem>
@@ -584,16 +585,11 @@ void Application::renderUpdatePopup() {
                                "installer or portable zip will replace this one.");
             ImGui::Spacing();
             if (ImGui::Button("Open Release Page", ImVec2(180, 0))) {
-                // openInBrowser lives in AboutDialog.cpp — duplicate the tiny
-                // platform helper inline so this file doesn't add a dependency.
-#ifdef _WIN32
-                ShellExecuteA(nullptr, "open", m_updateReleaseUrl.c_str(),
-                              nullptr, nullptr, SW_SHOWNORMAL);
-#else
-                std::string cmd = std::string("xdg-open ") + "\"" +
-                                  m_updateReleaseUrl + "\" >/dev/null 2>&1 &";
-                [[maybe_unused]] int rc = std::system(cmd.c_str());
-#endif
+                // m_updateReleaseUrl is the GitHub API's html_url — server
+                // controlled — so open it via the shell-free helper, pinned to
+                // github.com (a tampered response can neither inject a shell
+                // command nor redirect the user elsewhere).
+                materializr::openUrl(m_updateReleaseUrl, "https://github.com/");
             }
         } else {
             ImGui::TextColored(ImVec4(0.6f, 1.0f, 0.6f, 1.0f),

--- a/src/io/IgesIO.cpp
+++ b/src/io/IgesIO.cpp
@@ -12,12 +12,20 @@
 #include <BRep_Builder.hxx>
 #include <Interface_Static.hxx>
 #include <IFSelect_ReturnStatus.hxx>
+#include <Standard_Failure.hxx>
+#include <Standard_ErrorHandler.hxx>
 
 namespace materializr {
 
 ImportResult IgesIO::import(const std::string& filePath, Document& doc) {
     ImportResult result;
 
+    // OCCT can throw Standard_Failure / std::bad_alloc on malformed or adversarial
+    // IGES geometry (during TransferRoots / shape handling). Catch it so a bad
+    // import is a graceful error rather than an uncaught exception that aborts the
+    // whole process (an instant crash, notably on Android) — mirrors StepIO::import.
+    try {
+    OCC_CATCH_SIGNALS // convert an OCCT kernel fault on a crafted file into the catch below
     IGESControl_Reader reader;
     IFSelect_ReturnStatus status = reader.ReadFile(filePath.c_str());
 
@@ -100,6 +108,17 @@ ImportResult IgesIO::import(const std::string& filePath, Document& doc) {
 
     result.success = true;
     result.bodiesImported = importCount;
+    return result;
+    } catch (const Standard_Failure& e) {
+        result.success = false;
+        result.errorMessage = std::string("IGES import failed: ") + e.GetMessageString();
+    } catch (const std::exception& e) {
+        result.success = false;
+        result.errorMessage = std::string("IGES import failed: ") + e.what();
+    } catch (...) {
+        result.success = false;
+        result.errorMessage = "IGES import failed: unrecognized error";
+    }
     return result;
 }
 

--- a/src/io/ProjectIO.cpp
+++ b/src/io/ProjectIO.cpp
@@ -13,8 +13,10 @@
 #include <gp_Ax3.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>
+#include <Standard_Failure.hxx>
 
 #include <zlib.h>
+#include <cstdio>
 
 #include <cstddef>
 #include <fstream>
@@ -85,6 +87,21 @@ bool readBodyBlockV3(std::istream& ifs, const std::string& sbLine,
     std::string tok; std::size_t byteCount = 0;
     iss >> tok >> idOut >> byteCount;
     if (iss.fail()) return false;
+    // Bound the length-prefix against the bytes actually left before allocating
+    // from it (a crafted header could claim gigabytes). The loader feeds a
+    // seekable in-memory stream; on a non-seekable one tellg() is -1 and we fall
+    // back to an absolute ceiling.
+    {
+        std::streampos cur = ifs.tellg();
+        std::size_t remaining = 256u * 1024 * 1024;
+        if (cur >= 0) {
+            ifs.seekg(0, std::ios::end);
+            std::streampos endp = ifs.tellg();
+            ifs.seekg(cur);
+            remaining = (endp >= cur) ? static_cast<std::size_t>(endp - cur) : 0;
+        }
+        if (byteCount > remaining) return false;
+    }
     std::string data(byteCount, '\0');
     ifs.read(&data[0], static_cast<std::streamsize>(byteCount));
     if (static_cast<std::size_t>(ifs.gcount()) != byteCount) return false;
@@ -149,11 +166,20 @@ std::string gunzipInflate(const std::string& src) {
     std::string out;
     char buf[1 << 15];
     int ret;
+    // Decompression-bomb guard: a project is binary BREP + ASCII metadata; even
+    // large assemblies stay well under this. Without a ceiling a ~1 MB crafted
+    // .materializr (or autosave/recovery snapshot) inflates to many GB and OOMs.
+    const size_t maxOutput = 512u * 1024 * 1024; // 512 MB hard cap
     do {
         zs.next_out  = reinterpret_cast<Bytef*>(buf);
         zs.avail_out = sizeof(buf);
         ret = inflate(&zs, Z_NO_FLUSH);
         out.append(buf, sizeof(buf) - zs.avail_out);
+        if (out.size() > maxOutput) {
+            std::fprintf(stderr, "[ProjectIO] inflated size exceeded %zu bytes — refusing\n", maxOutput);
+            inflateEnd(&zs);
+            return {};
+        }
     } while (ret == Z_OK);
     inflateEnd(&zs);
     return (ret == Z_STREAM_END) ? out : std::string{};
@@ -165,6 +191,12 @@ ProjectSaveResult ProjectIO::save(const std::string& filePath, const Document& d
                                   const ProjectHistory* history) {
     ProjectSaveResult result;
 
+    // OCCT BinTools::Write (per body and inside the HISTORY blocks) can throw
+    // Standard_Failure on a degenerate in-memory shape; the inner per-body catch
+    // only handles std::exception and the history writes are unguarded. Wrap the
+    // whole save so Ctrl+S / autosave reports a graceful error instead of
+    // aborting the process and losing the document — mirrors load().
+    try {
     // Build the entire file content in memory first (binary-safe stringstream
     // so writeBodyBlockV3's raw bytes pass through unmodified), then gzip-
     // deflate the result and write it to disk as one binary blob. Lets the
@@ -435,6 +467,17 @@ ProjectSaveResult ProjectIO::save(const std::string& filePath, const Document& d
     out.close();
     result.success = true;
     return result;
+    } catch (const Standard_Failure& e) {
+        result.success = false;
+        result.errorMessage = std::string("Project save failed: ") + e.GetMessageString();
+    } catch (const std::exception& e) {
+        result.success = false;
+        result.errorMessage = std::string("Project save failed: ") + e.what();
+    } catch (...) {
+        result.success = false;
+        result.errorMessage = "Project save failed: unrecognized error";
+    }
+    return result;
 }
 
 namespace {
@@ -506,7 +549,7 @@ void parseSketchBodyImpl(std::istream& ifs, materializr::Sketch& sk,
             for (int i = 0; i < n && std::getline(ifs, line); ++i) {
                 std::istringstream s(line); std::string t; SketchSpline sp; int c = 0, cnt = 0;
                 s >> t >> sp.id >> c >> cnt; sp.isConstruction = (c != 0);
-                for (int k = 0; k < cnt; ++k) { int id = 0; s >> id; sp.controlPointIds.push_back(id); }
+                for (int k = 0; k < cnt; ++k) { int id = 0; if (!(s >> id)) break; sp.controlPointIds.push_back(id); }
                 bump(sp.id); sk.addRawSpline(sp);
             }
         } else if (tok == "POLYGON_COUNT") {
@@ -515,9 +558,9 @@ void parseSketchBodyImpl(std::istream& ifs, materializr::Sketch& sk,
                 std::istringstream s(line); std::string t; SketchPolygon g; int c = 0, nv = 0, nl = 0;
                 s >> t >> g.id >> g.centerPointId >> g.radius >> g.sides >> c >> nv;
                 g.isConstruction = (c != 0);
-                for (int k = 0; k < nv; ++k) { int id = 0; s >> id; g.vertexPointIds.push_back(id); }
+                for (int k = 0; k < nv; ++k) { int id = 0; if (!(s >> id)) break; g.vertexPointIds.push_back(id); }
                 s >> nl;
-                for (int k = 0; k < nl; ++k) { int id = 0; s >> id; g.lineIds.push_back(id); }
+                for (int k = 0; k < nl; ++k) { int id = 0; if (!(s >> id)) break; g.lineIds.push_back(id); }
                 bump(g.id); sk.addRawPolygon(g);
             }
         } else if (tok == "CONSTRAINT_COUNT") {
@@ -577,11 +620,26 @@ ProjectLoadResult ProjectIO::load(const std::string& filePath, Document& doc,
                                   ProjectHistory* historyOut) {
     ProjectLoadResult result;
 
+    // OCCT BinTools::Read / BRepTools::Read run on untrusted bytes below and throw
+    // Standard_Failure (NOT std::exception-derived) on malformed BREP; std parsing
+    // can throw too. Wrap the whole load so a hostile file is a graceful error
+    // rather than an uncaught exception that aborts the process.
+    try {
     // Slurp the whole file (binary). v2 files are plain ASCII; v3 files start
     // with the gzip magic and we inflate them in memory before parsing.
     std::ifstream raw(filePath, std::ios::in | std::ios::binary);
     if (!raw.is_open()) {
         result.errorMessage = "Failed to open file for reading: " + filePath;
+        return result;
+    }
+    // Reject an absurdly large file before pulling it into memory: the 512 MB
+    // gunzip cap only bounds *inflated* output, so a plain uncompressed v2 file
+    // would otherwise have no size gate at all.
+    raw.seekg(0, std::ios::end);
+    std::streampos rawSize = raw.tellg();
+    raw.seekg(0, std::ios::beg);
+    if (rawSize > static_cast<std::streampos>(512LL * 1024 * 1024)) {
+        result.errorMessage = "Project file too large (> 512 MB) — refusing to load";
         return result;
     }
     std::ostringstream slurp;
@@ -695,7 +753,19 @@ ProjectLoadResult ProjectIO::load(const std::string& filePath, Document& doc,
         TopoDS_Shape shape;
         if (fileVersion >= 3 && haveByteCount) {
             // v3 binary: read exactly bodyByteCount bytes, then expect a
-            // newline + "BODY_END" line.
+            // newline + "BODY_END" line. Bound the (untrusted) length-prefix
+            // against the bytes left in the file before allocating from it.
+            {
+                std::streampos here = ifs.tellg();
+                std::size_t remaining = (here >= 0 && static_cast<std::size_t>(here) <= contents.size())
+                                      ? contents.size() - static_cast<std::size_t>(here) : 0;
+                if (bodyByteCount > remaining) {
+                    result.errorMessage = "Body " + std::to_string(bodyId) + " claims " +
+                        std::to_string(bodyByteCount) + " bytes but only " +
+                        std::to_string(remaining) + " remain";
+                    return result;
+                }
+            }
             std::string data(bodyByteCount, '\0');
             ifs.read(&data[0], static_cast<std::streamsize>(bodyByteCount));
             if (static_cast<std::size_t>(ifs.gcount()) != bodyByteCount) {
@@ -929,8 +999,22 @@ ProjectLoadResult ProjectIO::load(const std::string& filePath, Document& doc,
                         // / arbitrary content, used for SketchEditOp's full
                         // before+after sketch snapshots.
                         std::size_t n = 0; ls >> n;
+                        // Bound the (untrusted) length-prefix against the bytes
+                        // left before allocating — same class as the body
+                        // byteCount guard, and reached on every project open.
+                        std::streampos here = ifs.tellg();
+                        std::size_t remaining = (here >= 0 && static_cast<std::size_t>(here) <= contents.size())
+                                              ? contents.size() - static_cast<std::size_t>(here) : 0;
+                        if (n > remaining) {
+                            result.errorMessage = "PARAMS_LEN exceeds remaining file size";
+                            return result;
+                        }
                         std::string data(n, '\0');
                         ifs.read(&data[0], static_cast<std::streamsize>(n));
+                        if (static_cast<std::size_t>(ifs.gcount()) != n) {
+                            result.errorMessage = "Short read on PARAMS_LEN blob";
+                            return result;
+                        }
                         // Consume the trailing newline after the blob.
                         std::string skip; std::getline(ifs, skip);
                         st.params = std::move(data);
@@ -945,7 +1029,7 @@ ProjectLoadResult ProjectIO::load(const std::string& filePath, Document& doc,
                         }
                     } else if (t == "DELETED_COUNT") {
                         int p = 0; ls >> p;
-                        for (int j = 0; j < p; ++j) { int id = 0; ls >> id; st.deleted.push_back(id); }
+                        for (int j = 0; j < p; ++j) { int id = 0; if (!(ls >> id)) break; st.deleted.push_back(id); }
                     } else if (t == "TIMESTAMP") {
                         ls >> st.timestampUnix;
                     }
@@ -958,6 +1042,17 @@ ProjectLoadResult ProjectIO::load(const std::string& filePath, Document& doc,
 
     result.success = true;
     result.bodiesLoaded = loadedCount;
+    return result;
+    } catch (const Standard_Failure& e) {
+        result.success = false;
+        result.errorMessage = std::string("Project load failed: ") + e.GetMessageString();
+    } catch (const std::exception& e) {
+        result.success = false;
+        result.errorMessage = std::string("Project load failed: ") + e.what();
+    } catch (...) {
+        result.success = false;
+        result.errorMessage = "Project load failed: unrecognized error";
+    }
     return result;
 }
 

--- a/src/io/StepIO.cpp
+++ b/src/io/StepIO.cpp
@@ -18,6 +18,7 @@
 #include <Interface_Static.hxx>
 #include <IFSelect_ReturnStatus.hxx>
 #include <Standard_Failure.hxx>
+#include <Standard_ErrorHandler.hxx>
 
 #include <cmath>
 
@@ -35,6 +36,7 @@ ImportResult StepIO::import(const std::string& filePath, Document& doc) {
     // surfaces as a graceful error instead of an uncaught exception that aborts
     // the whole process — which on Android shows up as an instant crash.
     try {
+    OCC_CATCH_SIGNALS // convert an OCCT kernel fault on a crafted file into the catch below
     STEPControl_Reader reader;
     IFSelect_ReturnStatus status = reader.ReadFile(filePath.c_str());
 

--- a/src/modeling/SvgImport.cpp
+++ b/src/modeling/SvgImport.cpp
@@ -183,8 +183,20 @@ bool findFirstUse(const std::string& svg, size_t& outStart, size_t& outEnd,
 
 void expandSvgUses(std::string& svg) {
     const int maxIter = 1024; // termination guard — pathological self-refs only
+    // Output-size cap defusing the "billion laughs" amplification: when a <use>
+    // target itself contains <use>, each expansion roughly doubles the buffer
+    // (L_k ~= 2^k * L0), so the iteration cap alone lets a few-hundred-byte file
+    // reach gigabytes. Abort once the working buffer crosses this bound.
+    const size_t maxOutput = std::min<size_t>(
+        std::max<size_t>(8u * 1024 * 1024, svg.size() * 32), 256u * 1024 * 1024);
     int expansions = 0;
     for (int it = 0; it < maxIter; ++it) {
+        if (svg.size() > maxOutput) {
+            std::fprintf(stderr,
+                "[SVG] <use> expansion exceeded %zu-byte cap — aborting\n",
+                maxOutput);
+            return;
+        }
         size_t us, ue;
         std::string href, attrs;
         if (!findFirstUse(svg, us, ue, href, attrs)) {
@@ -333,6 +345,15 @@ void inlineSvgCss(std::string& svg) {
     out.reserve(svg.size() + 1024);
     int injected = 0;
     for (size_t k = 0; k < svg.size(); ) {
+        // Amplification guard: CSS inlining injects a class's declarations into
+        // every matching element, so a large declaration across many elements is
+        // O(input^2). Stop once the output crosses an absolute ceiling and copy
+        // the remainder verbatim.
+        if (out.size() > 256u * 1024 * 1024) {
+            std::fprintf(stderr, "[SVG] inlineSvgCss exceeded byte budget — stopping\n");
+            out.append(svg, k, std::string::npos);
+            break;
+        }
         if (svg[k] != '<' || k + 1 >= svg.size() ||
             svg[k + 1] == '/' || svg[k + 1] == '!' || svg[k + 1] == '?') {
             out += svg[k++]; continue;
@@ -637,6 +658,13 @@ bool SvgImport::load(const std::string& path, SvgPaths& out) {
     std::ostringstream ss;
     ss << in.rdbuf();
     std::string text = ss.str();
+    // Absolute input cap: an SVG is vector art, not a bulk data file. Reject an
+    // oversized one before the (amplifying) preprocessing stages run, so the
+    // input N that drives their expansion/O(N^2) behaviour is itself bounded.
+    if (text.size() > 32u * 1024 * 1024) {
+        std::fprintf(stderr, "[SVG] file too large (%zu bytes) — refusing\n", text.size());
+        return false;
+    }
     inlineSvgCss(text);   // resolve <style> class fills → presentation attrs
     expandSvgText(text);  // render live <text> to glyph-outline <path>s
     expandSvgUses(text);

--- a/src/ui/AboutDialog.cpp
+++ b/src/ui/AboutDialog.cpp
@@ -1,17 +1,11 @@
 #include "UiTheme.h"
 #include "ui_scale.h"
 #include "AboutDialog.h"
+#include "url_open.h"
 #include <imgui.h>
 
-#include <cstdlib>
 #include <cstring>
 #include <string>
-
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <shellapi.h>
-#endif
 
 #ifndef MATERIALIZR_VERSION
 #define MATERIALIZR_VERSION "0.0.0"
@@ -21,16 +15,11 @@ namespace materializr {
 
 namespace {
 
-// Open a URL in the user's default browser. POSIX uses xdg-open; Windows uses
-// ShellExecuteA. No-op (and silently ignored) if the call fails — used only
-// for the GitHub link from the About dialog, which is a convenience.
+// Open a URL in the user's default browser via the shared shell-free helper
+// (see url_open.h). The About links are hardcoded https constants; openUrl
+// still validates the scheme and uses SDL_OpenURL rather than a shell.
 void openInBrowser(const char* url) {
-#ifdef _WIN32
-    ShellExecuteA(nullptr, "open", url, nullptr, nullptr, SW_SHOWNORMAL);
-#else
-    std::string cmd = std::string("xdg-open ") + "\"" + url + "\" >/dev/null 2>&1 &";
-    [[maybe_unused]] int rc = std::system(cmd.c_str());
-#endif
+    materializr::openUrl(url);
 }
 
 } // namespace

--- a/src/ui/UpdateChecker.cpp
+++ b/src/ui/UpdateChecker.cpp
@@ -18,7 +18,13 @@ namespace {
 // libcurl write callback: append into a std::string.
 size_t writeToString(void* contents, size_t size, size_t nmemb, void* userp) {
     size_t total = size * nmemb;
-    static_cast<std::string*>(userp)->append(static_cast<char*>(contents), total);
+    std::string* out = static_cast<std::string*>(userp);
+    // Response-size cap: the GitHub release JSON is a few KB. Refuse to grow past
+    // this so a hostile/huge response can't exhaust memory. Returning less than
+    // `total` makes libcurl abort the transfer with CURLE_WRITE_ERROR.
+    const size_t kMaxResponse = 4u * 1024 * 1024;
+    if (out->size() + total > kMaxResponse) return 0;
+    out->append(static_cast<char*>(contents), total);
     return total;
 }
 
@@ -68,7 +74,13 @@ std::vector<int> parseNumericComponents(const std::string& v) {
         size_t i = 0;
         while (i < tok.size() && std::isdigit(static_cast<unsigned char>(tok[i]))) ++i;
         if (i == 0) parts.push_back(0);
-        else parts.push_back(std::stoi(tok.substr(0, i)));
+        else {
+            // A hostile/oversized version token (e.g. a crafted tag_name with a
+            // 40-digit number) would make std::stoi throw out_of_range and crash
+            // the app on an uncaught exception — treat as 0 instead.
+            try { parts.push_back(std::stoi(tok.substr(0, i))); }
+            catch (...) { parts.push_back(0); }
+        }
     }
     return parts;
 }
@@ -107,6 +119,17 @@ UpdateChecker::Result UpdateChecker::check(const std::string& owner,
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
+    // Pin the request and any redirect target to HTTPS, so a redirect can't
+    // downgrade to http or jump to file://, etc. The *_STR forms are libcurl
+    // 7.85+; fall back to the numeric protocol bitmask on older libcurl.
+#if LIBCURL_VERSION_NUM >= 0x075500
+    curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "https");
+    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "https");
+#else
+    curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
+    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTPS);
+#endif
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToString);

--- a/src/url_open.h
+++ b/src/url_open.h
@@ -1,0 +1,47 @@
+#pragma once
+
+// Safe URL opener. Hands the URL to the OS via SDL_OpenURL, which does NOT run a
+// shell — unlike the old `std::system("xdg-open \"" + url + "\" ...")` path, where
+// a server-controlled release URL (the GitHub API's html_url) was an OS
+// command-injection vector ($(...), backticks, and quote-breakout all executed).
+//
+// Callers opening an UNTRUSTED url (anything derived from a network response)
+// MUST pass the expected host prefix, e.g. openUrl(url, "https://github.com/"),
+// so a tampered response can't redirect the user to an arbitrary destination.
+
+#include <SDL.h>
+#include <string>
+#include <cstdio>
+
+namespace materializr {
+
+inline bool openUrl(const std::string& url, const char* requiredPrefix = nullptr) {
+    // Scheme: https only — every link the app opens is an https resource.
+    if (url.rfind("https://", 0) != 0) {
+        std::fprintf(stderr, "openUrl: refusing non-https URL\n");
+        return false;
+    }
+    // Host pinning for untrusted (server-supplied) URLs.
+    if (requiredPrefix && url.rfind(requiredPrefix, 0) != 0) {
+        std::fprintf(stderr, "openUrl: URL did not match required prefix\n");
+        return false;
+    }
+    // Defense in depth: a valid URI never contains these unencoded (RFC 3986
+    // controls + "unsafe" set), and they are exactly what an injection payload
+    // needs. SDL_OpenURL never invokes a shell, so this is belt-and-suspenders.
+    for (unsigned char c : url) {
+        if (c < 0x20 || c >= 0x7f || c == ' ' || c == '"' || c == '<' ||
+            c == '>' || c == '\\' || c == '^' || c == '`' || c == '{' ||
+            c == '|' || c == '}') {
+            std::fprintf(stderr, "openUrl: refusing malformed URL\n");
+            return false;
+        }
+    }
+    if (SDL_OpenURL(url.c_str()) != 0) {
+        std::fprintf(stderr, "openUrl: SDL_OpenURL failed: %s\n", SDL_GetError());
+        return false;
+    }
+    return true;
+}
+
+} // namespace materializr


### PR DESCRIPTION
## What this does

Hardens the untrusted-input attack surface (file importers + the update flow), from a code audit. Defensive bounds/guards and a shell-free URL opener — **no behavior change for valid files**.

- **Command injection:** the update URL + About links now open via a shell-free `SDL_OpenURL` helper, with the server-supplied update URL pinned to `https://github.com/`.
- **Project/recovery loader (`ProjectIO`):** decompression-bomb cap (512 MB); both length-prefixes (body `byteCount` + `PARAMS_LEN`) bounded against remaining bytes; all count loops (`SPLINE`/`POLYGON`/`DELETED_COUNT`) stop on token exhaustion; whole-file size cap; `load()`/`save()` wrapped in OCCT-aware try/catch (`Standard_Failure` is not `std::exception`-derived).
- **SVG import:** `<use>` billion-laughs cap + absolute ceiling, 32 MB input cap, and an O(n²) guard on CSS inlining.
- **STEP/IGES:** import wrapped in try/catch (IGES previously had none) + `OCC_CATCH_SIGNALS`, so an OCCT kernel fault on a crafted file is catchable rather than fatal.
- **Update checker:** 4 MB response cap, `MAXREDIRS=5`, request + redirects pinned to https, and the version-token `std::stoi` guarded against hostile tags.

## How it was tested

Builds warning-clean; originally verified launching on macOS (Apple M4). Re-verified in the integrated tree on this machine: macOS arm64 Release build succeeds and `ctest` passes **7/7**. Upstream CI will exercise this branch on Linux/Windows.

## Checklist

- [x] Builds on desktop and tests pass — macOS arm64, `ctest` 7/7
- [x] No Android-specific changes; desktop behavior unchanged for valid files
- [x] n/a — hardening of existing import/update paths, no new feature
- [x] n/a — no touch-specific behavior
- [x] Code matches the style of the surrounding files

<!-- By submitting, I agree this contribution is licensed under GPL-3.0-or-later. -->
