### PR TITLE
Low-severity hardening tail

### DIFF
--- a/src/io/FileDialogs.cpp
+++ b/src/io/FileDialogs.cpp
@@ -364,6 +364,9 @@ void FileDialogs::openFile(const std::string& title,
     if (!seed.empty() && seed.back() != '/' && seed.back() != '\\') {
         seed += '/';
     }
+    // Never hand a path that begins with '-' to the backend: kdialog (and some
+    // others) read a leading-dash positional argument as an option flag.
+    if (!seed.empty() && seed[0] == '-') seed = "./" + seed;
     s_async.openH = std::make_unique<pfd::open_file>(
         title, seed, pfdFilters(filters));
     s_async.callback = std::move(callback);
@@ -395,6 +398,7 @@ void FileDialogs::saveFile(const std::string& title,
         if (!defaultName.empty()) p /= defaultName;
         seed = p.string();
     }
+    if (!seed.empty() && seed[0] == '-') seed = "./" + seed; // see openFile note
     s_async.saveH = std::make_unique<pfd::save_file>(
         title, seed, pfdFilters(filters),
         pfd::opt::force_overwrite);

--- a/src/io/IgesIO.cpp
+++ b/src/io/IgesIO.cpp
@@ -40,6 +40,16 @@ ImportResult IgesIO::import(const std::string& filePath, Document& doc) {
         return result;
     }
 
+    // Bound the work before the (synchronous, UI-thread) transfer: a crafted file
+    // with a huge root/entity count would otherwise drive unbounded allocation and
+    // time, and the per-sub-shape importCount could in theory overflow. 100k is far
+    // beyond any real IGES model.
+    const Standard_Integer kMaxEntities = 100000;
+    if (reader.NbRootsForTransfer() > kMaxEntities) {
+        result.errorMessage = "IGES file has too many entities to import";
+        return result;
+    }
+
     // Transfer all roots
     Standard_Integer nbRoots = reader.TransferRoots();
     if (nbRoots == 0) {
@@ -51,6 +61,10 @@ ImportResult IgesIO::import(const std::string& filePath, Document& doc) {
 
     // Iterate over transferred shapes
     for (Standard_Integer i = 1; i <= reader.NbShapes(); ++i) {
+        if (importCount >= kMaxEntities) {
+            result.errorMessage = "IGES file produced too many bodies to import";
+            return result;
+        }
         TopoDS_Shape shape = reader.Shape(i);
 
         // Explore for solids first

--- a/src/io/Settings.cpp
+++ b/src/io/Settings.cpp
@@ -344,6 +344,17 @@ AppSettings SettingsIO::importJson(const std::string& path, bool* ok) {
     auto kv = parseFlatJson(ss.str());
     if (kv.empty()) { if (ok) *ok = false; return s; } // unparseable / empty
 
+    // Symmetry with exportJson, which omits these machine-local/session keys so a
+    // shared file stays portable. Strip them on import too, so a planted settings
+    // file can't inject this machine's session state (a lastProjectPath that
+    // becomes a silent save target, a lastFileDir, or fabricated recents).
+    kv.erase("lastProjectPath");
+    kv.erase("lastFileDir");
+    for (auto it = kv.begin(); it != kv.end(); ) {
+        if (it->first.rfind("recent", 0) == 0) it = kv.erase(it);
+        else ++it;
+    }
+
     applyKv(kv, s);
     if (ok) *ok = true;
     return s;

--- a/src/io/portable-file-dialogs.h
+++ b/src/io/portable-file-dialogs.h
@@ -1154,9 +1154,10 @@ inline std::string internal::file_dialog::string_result()
 #if _WIN32
     return m_async->result();
 #else
-    // Strip the newline character
+    // Strip the newline character. (Local patch: guard ret.back() — a cancelled
+    // dialog returns an empty string, and back() on it is undefined behaviour.)
     auto ret = m_async->result();
-    return ret.back() == '\n' ? ret.substr(0, ret.size() - 1) : ret;
+    return (!ret.empty() && ret.back() == '\n') ? ret.substr(0, ret.size() - 1) : ret;
 #endif
 }
 

--- a/src/modeling/SvgImport.cpp
+++ b/src/modeling/SvgImport.cpp
@@ -647,6 +647,13 @@ bool SvgImport::load(const std::string& path, SvgPaths& out) {
         std::fprintf(stderr, "[SVG] cannot parse '%s'\n", path.c_str());
         return false;
     }
+    // Reject non-finite image dimensions: a crafted SVG can make nanosvg's number
+    // parser yield inf/NaN, which would poison `ref`, the bounds, and the scale.
+    if (!std::isfinite(img->width) || !std::isfinite(img->height)) {
+        std::fprintf(stderr, "[SVG] non-finite image dimensions — refusing\n");
+        nsvgDelete(img);
+        return false;
+    }
     const float ref = std::max(1.0f, std::max(img->width, img->height));
 
     bool haveBB = false;
@@ -659,6 +666,13 @@ bool SvgImport::load(const std::string& path, SvgPaths& out) {
         const bool filled = (sh->fill.type != NSVG_PAINT_NONE);
         for (NSVGpath* p = sh->paths; p; p = p->next) {
             if (p->npts < 4) continue;
+            // Skip paths with non-finite coordinates (a crafted SVG can make
+            // nanosvg emit inf/NaN); they'd otherwise poison the bounds and the
+            // (int) cast in sampleCubic (UB).
+            bool finite = true;
+            for (int i = 0; i < p->npts * 2; ++i)
+                if (!std::isfinite(p->pts[i])) { finite = false; break; }
+            if (!finite) continue;
             std::vector<glm::vec2> pts;
             pts.push_back(glm::vec2(p->pts[0], p->pts[1]));
             for (int i = 0; i < p->npts - 1; i += 3)

--- a/src/third_party/nanosvg.h
+++ b/src/third_party/nanosvg.h
@@ -732,9 +732,15 @@ static void nsvg__resetPath(NSVGparser* p)
 static void nsvg__addPoint(NSVGparser* p, float x, float y)
 {
 	if (p->npts+1 > p->cpts) {
-		p->cpts = p->cpts ? p->cpts*2 : 8;
-		p->pts = (float*)realloc(p->pts, p->cpts*2*sizeof(float));
-		if (!p->pts) return;
+		// Local patch: realloc into a temp and only advance cpts on success. The
+		// original advanced cpts first, so on realloc failure it left pts=NULL with
+		// a stale (already-doubled) cpts — a later addPoint would then skip the grow
+		// and write through the NULL pointer (and the old buffer leaked).
+		int newcpts = p->cpts ? p->cpts*2 : 8;
+		float* np = (float*)realloc(p->pts, newcpts*2*sizeof(float));
+		if (!np) return;
+		p->pts = np;
+		p->cpts = newcpts;
 	}
 	p->pts[p->npts*2+0] = x;
 	p->pts[p->npts*2+1] = y;


### PR DESCRIPTION
## What this does

Contained low-severity fixes from the same security audit (the tail of the hardening pass) — small, self-contained guards with no behavior change for valid input:

- `portable-file-dialogs`: `.back()` on a possibly-empty string (UB) + a `kdialog` arg-injection guard.
- IGES: entity/body caps.
- `nanosvg`: realloc UB fix.
- SVG import: `inf`/`NaN` finiteness checks.
- `Settings`: import/export symmetry.

## How it was tested

Re-verified in the integrated tree on macOS (Apple M4): arm64 Release build succeeds and `ctest` passes **7/7**. Upstream CI will exercise this branch on Linux/Windows.

## Checklist

- [x] Builds on desktop and tests pass — macOS arm64, `ctest` 7/7
- [x] No Android-specific changes; desktop behavior unchanged for valid input
- [x] n/a — small hardening guards, no new feature
- [x] n/a — no touch-specific behavior
- [x] Code matches the style of the surrounding files

<!-- By submitting, I agree this contribution is licensed under GPL-3.0-or-later. -->
