### PR TITLE
Fix two High-severity correctness bugs (undo/redo desync, threaded data race)

### DIFF
--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -2135,6 +2135,12 @@ void Application::handleToolAction(int action) {
 }
 
 void Application::handleShortcuts() {
+    // A threaded thread-cut compute is in flight (its modal popup is up). Suppress
+    // shortcuts until it resolves: undo/redo/delete would mutate the document — and
+    // the worker's target body — out from under the in-flight op, whose result is
+    // pushed on the main thread when the future lands.
+    if (m_threadComputing) return;
+
     ImGuiIO& io = ImGui::GetIO();
 
     // Undo/Redo — poll the hardware Ctrl state directly so it works even when

--- a/src/app/Application_InteractiveOps.cpp
+++ b/src/app/Application_InteractiveOps.cpp
@@ -65,6 +65,7 @@
 #include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
 #include <TopTools_ListOfShape.hxx>
 #include <BRep_Builder.hxx>
+#include <BRepBuilderAPI_Copy.hxx>
 #include <BRepPrimAPI_MakePrism.hxx>
 #include <gp_Cylinder.hxx>
 #include <gp_Ax2.hxx>
@@ -761,12 +762,20 @@ void Application::commitThread() {
         return;
     }
     std::fprintf(stderr, "[Thread] Apply: launching worker\n");
-    // Kick the multi-second sweep + boolean onto a worker thread. The shape
-    // handle is copied in (OCCT handles are atomically refcounted) and the
-    // worker touches no Document state; renderThreadPanel polls the future
-    // and pushes the real op — with the precomputed result — when it lands.
-    TopoDS_Shape body;
-    try { body = m_document->getBody(m_threadBodyId); } catch (...) {}
+    // Kick the multi-second sweep + boolean onto a worker thread. renderThreadPanel
+    // polls the future and pushes the real op — with the precomputed result — when
+    // it lands.
+    //
+    // DEEP-COPY the shape into the worker. A bare TopoDS_Shape handle copy is
+    // refcount-shared with the live document's TShape, whose lazy OCCT caches
+    // (triangulation, bounding box, surface adaptors) the RENDER thread populates
+    // and reads every frame — concurrent read/write on the same TShape is a data
+    // race (UB → intermittent crash/corruption). BRepBuilderAPI_Copy gives the
+    // worker an independent TShape, so the two threads share nothing.
+    TopoDS_Shape live;
+    try { live = m_document->getBody(m_threadBodyId); } catch (...) {}
+    if (live.IsNull()) { cancelThread(); return; }
+    TopoDS_Shape body = BRepBuilderAPI_Copy(live).Shape();
     if (body.IsNull()) { cancelThread(); return; }
     auto worker = std::make_shared<ThreadOp>();
     {

--- a/src/core/History.cpp
+++ b/src/core/History.cpp
@@ -84,18 +84,30 @@ bool History::undo(Document& doc) {
         return false;
     }
 
-    Operation* op = m_operations[m_currentIndex].get();
+    // A DISABLED step at the tip was never applied (replayAll skips disabled ops),
+    // so calling its undo() would revert geometry that never existed. Walk the tip
+    // down past any disabled steps and undo the last ACTUALLY-APPLIED (enabled) one.
+    int idx = m_currentIndex;
+    while (idx > m_undoFloor && !m_operations[idx]->isEnabled()) idx--;
+    if (idx <= m_undoFloor) {
+        // Only disabled (never-applied) steps sit above the floor — nothing to undo.
+        std::fprintf(stderr, "[History] undo: only disabled steps above floor (currentIndex=%d)\n",
+                     m_currentIndex);
+        return false;
+    }
+
+    Operation* op = m_operations[idx].get();
     std::fprintf(stderr, "[History] undo step %d '%s' (type=%s reloaded=%d enabled=%d)\n",
-                 m_currentIndex, op->name().c_str(), op->typeId().c_str(),
+                 idx, op->name().c_str(), op->typeId().c_str(),
                  op->isReloaded() ? 1 : 0, op->isEnabled() ? 1 : 0);
     if (!op->undo(doc)) {
         std::fprintf(stderr, "[History] undo FAILED at step %d '%s' — op->undo() "
                              "returned false; staying at this step\n",
-                     m_currentIndex, op->name().c_str());
+                     idx, op->name().c_str());
         return false;
     }
 
-    m_currentIndex--;
+    m_currentIndex = idx - 1;
     // Manual undo means the user is steering the applied range themselves —
     // drop any pending auto-recovery so a later edit doesn't surprise-redo
     // steps they deliberately walked back past.
@@ -109,14 +121,26 @@ bool History::redo(Document& doc) {
         return false;
     }
 
-    m_currentIndex++;
-    Operation* op = m_operations[m_currentIndex].get();
-    if (!op->execute(doc)) {
-        m_failedReplayAt = m_currentIndex;
-        m_currentIndex--;
-        return false;
+    // Skip DISABLED steps: they are suppressed, so executing one would re-apply
+    // geometry the user turned off. Advance to the next ENABLED step and run it.
+    const int n = static_cast<int>(m_operations.size());
+    int idx = m_currentIndex + 1;
+    while (idx < n && !m_operations[idx]->isEnabled()) idx++;
+    if (idx >= n) {
+        // Only disabled steps remain in the redo range — consume them (advance the
+        // tip past them, no execution) so Ctrl+Y doesn't keep firing with no effect.
+        m_currentIndex = n - 1;
+        if (m_eventBus) m_eventBus->publish(materializr::HistoryStepEvent{m_currentIndex, false});
+        return true;
     }
 
+    Operation* op = m_operations[idx].get();
+    if (!op->execute(doc)) {
+        m_failedReplayAt = idx;
+        return false; // leave the tip below the failed step
+    }
+
+    m_currentIndex = idx;
     op->rememberGoodParams();
     if (m_failedReplayAt >= 0 && m_currentIndex >= m_failedReplayAt) {
         m_failedReplayAt = -1; // the previously-failed step recomputed fine

--- a/tests/test_history.cpp
+++ b/tests/test_history.cpp
@@ -212,3 +212,42 @@ TEST(HistoryTest, GetStepOutOfBoundsReturnsNull) {
     EXPECT_EQ(history.getStep(0), nullptr);
     EXPECT_EQ(history.getStep(100), nullptr);
 }
+
+// Regression: disabling a step then undo/redo must respect isEnabled(). A
+// disabled step is never applied (replayAll skips it), so undo() must not call
+// undo() on it (it would revert geometry that never existed) and redo() must not
+// execute it. Mirrors the HistoryPanel Disable + replayAll flow.
+TEST(HistoryTest, UndoRedoSkipDisabledSteps) {
+    Document doc;
+    History history;
+    for (int i = 0; i < 3; i++)
+        history.pushOperation(std::make_unique<MockAddBodyOp>(10.0 + i), doc);
+    ASSERT_EQ(doc.bodyCount(), 3);
+    ASSERT_EQ(history.currentStep(), 2);
+
+    // Disable the TIP step (2) and rebuild — replayAll re-executes only 0 and 1,
+    // but lands currentIndex on the (disabled) tip at index 2.
+    const_cast<Operation*>(history.getStep(2))->setEnabled(false);
+    history.replayAll(doc);
+    EXPECT_EQ(doc.bodyCount(), 2);
+    EXPECT_EQ(history.currentStep(), 2);
+
+    // Undo must skip the never-applied disabled tip and undo step 1 (the last
+    // applied step). The pre-fix code undid the disabled step → no real change
+    // and a desynced index (this would leave bodyCount() == 2).
+    EXPECT_TRUE(history.undo(doc));
+    EXPECT_EQ(doc.bodyCount(), 1);
+    EXPECT_EQ(history.currentStep(), 0);
+
+    // Redo re-applies step 1.
+    EXPECT_TRUE(history.redo(doc));
+    EXPECT_EQ(doc.bodyCount(), 2);
+    EXPECT_EQ(history.currentStep(), 1);
+
+    // A second redo must SKIP the disabled step 2 (not execute it): body count
+    // stays 2 and the redo range is consumed.
+    EXPECT_TRUE(history.redo(doc));
+    EXPECT_EQ(doc.bodyCount(), 2);
+    EXPECT_EQ(history.currentStep(), 2);
+    EXPECT_FALSE(history.canRedo());
+}


### PR DESCRIPTION
## What this does

Fixes two high-severity correctness bugs:

- **Undo/redo desync.** `undo()`/`redo()` now respect `isEnabled()`, so a disabled history step no longer desyncs the model from the history. Adds a regression test (`tests/test_history.cpp`).
- **Threaded data race.** The threaded thread-cut worker now gets a `BRepBuilderAPI_Copy` deep copy instead of sharing the live document's `TShape` with the render thread, and shortcuts are suppressed during the compute.

## How it was tested

New regression test in `tests/test_history.cpp` covers the undo/redo-with-disabled-step case. Verified on this machine: macOS arm64 Release build succeeds and `ctest` passes **7/7** (including `test_history`). Upstream CI will exercise this branch on Linux/Windows.

## Checklist

- [x] Builds on desktop and tests pass — macOS arm64, `ctest` 7/7 incl. `test_history`
- [x] No Android-specific changes; desktop behavior corrected, not otherwise changed
- [x] n/a — core correctness fix, not a new feature
- [x] n/a — no touch-specific behavior
- [x] Code matches the style of the surrounding files

<!-- By submitting, I agree this contribution is licensed under GPL-3.0-or-later. -->
