### PR TITLE
im-touch tree: stop ##LiteTree spamming the ImGui boundary warning

### DIFF
--- a/src/ui/TouchWidgets.cpp
+++ b/src/ui/TouchWidgets.cpp
@@ -604,6 +604,21 @@ TreeLeafAction treeLeaf(const char* id, const char* icon, const char* label,
     const ImVec2 p = ImGui::GetCursorScreenPos();
     ImDrawList* dl = ImGui::GetWindowDrawList();
 
+    // Claim the whole row rect up front. The internals below are placed with
+    // SetCursorScreenPos, and ImGui flags any such jump past the window's
+    // current content max ("uses SetCursorPos to extend window boundaries —
+    // submit an item e.g. Dummy()") — which, unfixed, fired every frame for
+    // the im-touch Bodies tree (##LiteTree). Same lesson as listRow: claim the
+    // rect with a Dummy, and derive the row bottom the way ItemSize() does
+    // (post-Dummy cursor minus spacing) rather than the raw p.y + h — at a
+    // fractional uiScale ImGui truncates the item advance to whole pixels, so
+    // p.y + h overshoots the claimed max by the fraction and trips the warning
+    // on every row. The max() guards the first auto-resize frame where the
+    // content region reports ~0 wide.
+    ImGui::Dummy(ImVec2(std::max(w, indent + eyeW + swW + 1.0f), h));
+    const float rowBottom =
+        ImGui::GetCursorScreenPos().y - ImGui::GetStyle().ItemSpacing.y;
+
     // Eye first — its own exclusive hit area (a row button submitted before
     // it would swallow the taps; same lesson as listRow's checkbox).
     ImGui::SetCursorScreenPos(ImVec2(p.x + indent, p.y));
@@ -667,7 +682,9 @@ TreeLeafAction treeLeaf(const char* id, const char* icon, const char* label,
         dl->AddRect(a, b, ImGui::GetColorU32(textDim()), radius(4.0f * s));
     }
 
-    ImGui::SetCursorScreenPos(ImVec2(p.x, p.y + h));
+    // rowBottom is bit-exact with the Dummy's claimed max, so stacking the
+    // next row here never re-extends the boundary.
+    ImGui::SetCursorScreenPos(ImVec2(p.x, rowBottom));
     ImGui::PopID();
     return act;
 }


### PR DESCRIPTION
## Problem

Opening the **im-touch** layout (or any view showing the Bodies tree) fires the Dear ImGui recoverable-error banner **every frame**:

> `In window '##LiteTree': Code uses SetCursorPos()/SetCursorScreenPos() to extend window/parent boundaries. Please submit an item e.g. Dummy() afterwards in order to grow window/parent boundaries.`

The recurring error-recovery pass pins im-touch to ~12 fps and paints a large red overlay over the floating controls.

## Cause

`touchui::treeLeaf` (src/ui/TouchWidgets.cpp) places its eye / swatch / row hit areas with `SetCursorScreenPos` and then stacks the next row at the **raw `p.y + h`**. ImGui truncates item advances to whole pixels, so at a fractional `uiScale` (s ≈ 1.7 on Retina) that raw bottom overshoots the claimed content max by the fraction — tripping the boundary warning on every row. Same failure mode the sibling `listRow` already documents and guards against.

## Fix

Mirror `listRow`'s solution in `treeLeaf`:
- Claim the whole row rect with a `Dummy()` up front (`max()`-guarded for the first ~0-wide auto-resize frame).
- Stack the next row at the **bit-exact `rowBottom`** (post-`Dummy` cursor minus `ItemSpacing`) instead of `p.y + h`.

`treeGroup` already ends on a real item, so only `treeLeaf` needed it.

## Verification

- Warning gone; im-touch Bodies tree renders clean; **fps 12 → 60**.
- Full `ctest`: **27/27**.
- im-touch circle/rectangle **confirm-bubble** path unaffected (drag-release still holds the shape and offers the seeded Diameter/W×H well + ✗/✓; ✓ commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)