### PR TITLE
Section View: fill the cross-section cap (fixes #15)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ add_executable(materializr
     src/viewport/Gizmo.cpp
     src/viewport/BoxSelect.cpp
     src/viewport/SectionView.cpp
+    src/viewport/SectionCap.cpp
     src/viewport/SelectionHighlight.cpp
     src/ui/Toolbar.cpp
     src/ui/TouchWidgets.cpp

--- a/src/viewport/SectionCap.cpp
+++ b/src/viewport/SectionCap.cpp
@@ -4,6 +4,8 @@
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepPrimAPI_MakeHalfSpace.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
+#include <Bnd_Box.hxx>
+#include <BRepBndLib.hxx>
 #include <BRepAdaptor_Surface.hxx>
 #include <GeomAbs_SurfaceType.hxx>
 #include <Poly_Triangulation.hxx>
@@ -30,8 +32,34 @@ bool computeSectionCap(const TopoDS_Shape& shape, const gp_Pln& cuttingPlane,
         // solid it keeps is the -normal half-space. Intersect the body with
         // that half-space and fill the new planar faces sitting on the cut
         // plane, otherwise a solid body reads as a hollow shell.
-        gp_Dir n = cuttingPlane.Axis().Direction();
-        gp_Pnt loc = cuttingPlane.Location();
+        const gp_Dir n = cuttingPlane.Axis().Direction();
+        const gp_Pnt loc = cuttingPlane.Location();
+
+        // Cheap reject: only proceed when the plane strictly cuts the body
+        // (material on BOTH sides). This skips the Common+mesh for bodies the
+        // plane never touches (avoids per-frame cost while dragging the offset
+        // slider) and, since it demands material on the removed side too, stops
+        // a plane that merely grazes a boundary face from drawing a spurious
+        // cap over that untouched face.
+        Bnd_Box bbox;
+        BRepBndLib::Add(shape, bbox);
+        if (bbox.IsVoid()) return false;
+        double xmin, ymin, zmin, xmax, ymax, zmax;
+        bbox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+        const gp_Pnt corners[8] = {
+            gp_Pnt(xmin, ymin, zmin), gp_Pnt(xmax, ymin, zmin),
+            gp_Pnt(xmin, ymax, zmin), gp_Pnt(xmax, ymax, zmin),
+            gp_Pnt(xmin, ymin, zmax), gp_Pnt(xmax, ymin, zmax),
+            gp_Pnt(xmin, ymax, zmax), gp_Pnt(xmax, ymax, zmax)};
+        double dLo = 1e300, dHi = -1e300;
+        for (const gp_Pnt& c : corners) {
+            const double d = gp_Vec(loc, c).Dot(gp_Vec(n));
+            if (d < dLo) dLo = d;
+            if (d > dHi) dHi = d;
+        }
+        const double straddleEps = 1e-6;
+        if (!(dLo < -straddleEps && dHi > straddleEps)) return false;
+
         const double L = 1.0e5; // plane extent; must bisect any body
         TopoDS_Face planeFace =
             BRepBuilderAPI_MakeFace(cuttingPlane, -L, L, -L, L).Face();
@@ -78,7 +106,10 @@ bool computeSectionCap(const TopoDS_Shape& shape, const gp_Pln& cuttingPlane,
             }
         }
     } catch (...) {
-        return outPositions.size() > startSize;
+        // Never hand back a half-built cap: roll back any partial append so a
+        // failure renders as "no cap" rather than broken geometry.
+        outPositions.resize(startSize);
+        return false;
     }
 
     return outPositions.size() > startSize;

--- a/src/viewport/SectionCap.cpp
+++ b/src/viewport/SectionCap.cpp
@@ -1,0 +1,87 @@
+#include "SectionCap.h"
+
+#include <BRepAlgoAPI_Common.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepPrimAPI_MakeHalfSpace.hxx>
+#include <BRepMesh_IncrementalMesh.hxx>
+#include <BRepAdaptor_Surface.hxx>
+#include <GeomAbs_SurfaceType.hxx>
+#include <Poly_Triangulation.hxx>
+#include <TopLoc_Location.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <BRep_Tool.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Vec.hxx>
+#include <gp_Trsf.hxx>
+
+namespace materializr {
+
+bool computeSectionCap(const TopoDS_Shape& shape, const gp_Pln& cuttingPlane,
+                       std::vector<float>& outPositions) {
+    if (shape.IsNull()) return false;
+
+    const size_t startSize = outPositions.size();
+
+    try {
+        // ShapeRenderer clips away the +normal half (discard dot>0), so the
+        // solid it keeps is the -normal half-space. Intersect the body with
+        // that half-space and fill the new planar faces sitting on the cut
+        // plane, otherwise a solid body reads as a hollow shell.
+        gp_Dir n = cuttingPlane.Axis().Direction();
+        gp_Pnt loc = cuttingPlane.Location();
+        const double L = 1.0e5; // plane extent; must bisect any body
+        TopoDS_Face planeFace =
+            BRepBuilderAPI_MakeFace(cuttingPlane, -L, L, -L, L).Face();
+        gp_Pnt refPnt = loc.Translated(gp_Vec(n) * -1.0); // kept (solid) side
+        TopoDS_Shape halfSpace =
+            BRepPrimAPI_MakeHalfSpace(planeFace, refPnt).Solid();
+
+        BRepAlgoAPI_Common common(shape, halfSpace);
+        common.Build();
+        if (!common.IsDone()) return false;
+        const TopoDS_Shape& capped = common.Shape();
+        if (capped.IsNull()) return false;
+
+        BRepMesh_IncrementalMesh mesher(capped, 0.1);
+        mesher.Perform();
+
+        const double planeTol = 1.0e-3;
+        for (TopExp_Explorer fexp(capped, TopAbs_FACE); fexp.More(); fexp.Next()) {
+            const TopoDS_Face& face = TopoDS::Face(fexp.Current());
+            BRepAdaptor_Surface surf(face);
+            if (surf.GetType() != GeomAbs_Plane) continue;
+            gp_Pln fp = surf.Plane();
+            // Cap faces lie ON the cut plane: parallel normal + point on plane.
+            if (!fp.Axis().Direction().IsParallel(n, 0.01)) continue;
+            if (cuttingPlane.Distance(fp.Location()) > planeTol) continue;
+
+            TopLoc_Location tloc;
+            Handle(Poly_Triangulation) tri = BRep_Tool::Triangulation(face, tloc);
+            if (tri.IsNull()) continue;
+            const gp_Trsf& trsf = tloc.Transformation();
+
+            for (int t = 1; t <= tri->NbTriangles(); ++t) {
+                int a = 0, b = 0, c = 0;
+                tri->Triangle(t).Get(a, b, c);
+                const gp_Pnt verts[3] = {
+                    tri->Node(a).Transformed(trsf),
+                    tri->Node(b).Transformed(trsf),
+                    tri->Node(c).Transformed(trsf)};
+                for (const gp_Pnt& p : verts) {
+                    outPositions.push_back(static_cast<float>(p.X()));
+                    outPositions.push_back(static_cast<float>(p.Y()));
+                    outPositions.push_back(static_cast<float>(p.Z()));
+                }
+            }
+        }
+    } catch (...) {
+        return outPositions.size() > startSize;
+    }
+
+    return outPositions.size() > startSize;
+}
+
+} // namespace materializr

--- a/src/viewport/SectionCap.h
+++ b/src/viewport/SectionCap.h
@@ -6,8 +6,8 @@
 namespace materializr {
 
 // Fill the cross-section of `shape` cut by `cuttingPlane`. Appends triangle
-// positions (x,y,z per vertex) of the planar cap faces — the region where the
-// plane passes through solid material — so a section-clipped solid does not
+// positions (x,y,z per vertex) of the planar cap faces - the region where the
+// plane passes through solid material - so a section-clipped solid does not
 // read as a hollow shell. Keeps the -normal half-space, matching the viewport
 // shader which discards the +normal side. Returns true if any cap was produced.
 //

--- a/src/viewport/SectionCap.h
+++ b/src/viewport/SectionCap.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <gp_Pln.hxx>
+#include <TopoDS_Shape.hxx>
+#include <vector>
+
+namespace materializr {
+
+// Fill the cross-section of `shape` cut by `cuttingPlane`. Appends triangle
+// positions (x,y,z per vertex) of the planar cap faces — the region where the
+// plane passes through solid material — so a section-clipped solid does not
+// read as a hollow shell. Keeps the -normal half-space, matching the viewport
+// shader which discards the +normal side. Returns true if any cap was produced.
+//
+// Pure OCCT (no GL) so it is testable headless.
+bool computeSectionCap(const TopoDS_Shape& shape, const gp_Pln& cuttingPlane,
+                       std::vector<float>& outPositions);
+
+} // namespace materializr

--- a/src/viewport/SectionView.cpp
+++ b/src/viewport/SectionView.cpp
@@ -1,5 +1,6 @@
 #include "gl_common.h"
 #include "SectionView.h"
+#include "SectionCap.h"
 #include "../core/Document.h"
 
 #include <glm/gtc/type_ptr.hpp>
@@ -13,6 +14,7 @@
 #include <BRep_Tool.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>
+#include <gp_Vec.hxx>
 #include <gp_Ax3.hxx>
 
 #include <cstdio>
@@ -37,12 +39,38 @@ void main() {
 }
 )";
 
+// Cap fill: the cross-section is planar (one normal for the whole cap), so a
+// flat shade off that normal is enough to read as solid cut material.
+static const char* s_capVertSource = R"(
+#version 330 core
+layout(location = 0) in vec3 a_position;
+uniform mat4 u_mvp;
+void main() {
+    gl_Position = u_mvp * vec4(a_position, 1.0);
+}
+)";
+
+static const char* s_capFragSource = R"(
+#version 330 core
+uniform vec3 u_color;
+uniform vec3 u_normal; // cut-plane normal (world)
+out vec4 fragColor;
+void main() {
+    vec3 L = normalize(vec3(0.4, 0.7, 0.6));
+    float d = 0.45 + 0.55 * abs(dot(normalize(u_normal), L));
+    fragColor = vec4(u_color * d, 1.0);
+}
+)";
+
 SectionView::SectionView() {}
 
 SectionView::~SectionView() {
     if (m_program) glDeleteProgram(m_program);
     if (m_vao) glDeleteVertexArrays(1, &m_vao);
     if (m_vbo) glDeleteBuffers(1, &m_vbo);
+    if (m_capProgram) glDeleteProgram(m_capProgram);
+    if (m_capVao) glDeleteVertexArrays(1, &m_capVao);
+    if (m_capVbo) glDeleteBuffers(1, &m_capVbo);
 }
 
 bool SectionView::initialize() {
@@ -77,6 +105,38 @@ bool SectionView::initialize() {
     glGenVertexArrays(1, &m_vao);
     glGenBuffers(1, &m_vbo);
 
+    // Cap fill program
+    unsigned int cvert = 0, cfrag = 0;
+    if (!compileShader(cvert, GL_VERTEX_SHADER, s_capVertSource)) return false;
+    if (!compileShader(cfrag, GL_FRAGMENT_SHADER, s_capFragSource)) {
+        glDeleteShader(cvert);
+        return false;
+    }
+    m_capProgram = glCreateProgram();
+    glAttachShader(m_capProgram, cvert);
+    glAttachShader(m_capProgram, cfrag);
+    glLinkProgram(m_capProgram);
+    glDeleteShader(cvert);
+    glDeleteShader(cfrag);
+
+    int capOk = 0;
+    glGetProgramiv(m_capProgram, GL_LINK_STATUS, &capOk);
+    if (!capOk) {
+        char log[512];
+        glGetProgramInfoLog(m_capProgram, 512, nullptr, log);
+        std::fprintf(stderr, "SectionView cap link error: %s\n", log);
+        glDeleteProgram(m_capProgram);
+        m_capProgram = 0;
+        return false;
+    }
+
+    m_capLocMVP = glGetUniformLocation(m_capProgram, "u_mvp");
+    m_capLocColor = glGetUniformLocation(m_capProgram, "u_color");
+    m_capLocNormal = glGetUniformLocation(m_capProgram, "u_normal");
+
+    glGenVertexArrays(1, &m_capVao);
+    glGenBuffers(1, &m_capVbo);
+
     return true;
 }
 
@@ -102,6 +162,7 @@ bool SectionView::isEnabled() const {
 
 void SectionView::update() {
     m_lines.clear();
+    m_caps.clear();
 
     if (!m_enabled || !m_document) return;
 
@@ -112,6 +173,13 @@ void SectionView::update() {
         gp_Dir normal = cuttingPlane.Axis().Direction();
         origin.Translate(gp_Vec(normal) * static_cast<double>(m_offset));
         cuttingPlane.SetLocation(origin);
+    }
+
+    {
+        gp_Dir cn = cuttingPlane.Axis().Direction();
+        m_capNormal = glm::vec3(static_cast<float>(cn.X()),
+                                static_cast<float>(cn.Y()),
+                                static_cast<float>(cn.Z()));
     }
 
     // Iterate all bodies and compute section curves
@@ -160,6 +228,13 @@ void SectionView::update() {
                     continue;
                 }
             }
+
+            // --- Cross-section cap ---
+            // Without a filled cap the clipped solid reads as a hollow shell.
+            CapMesh cap;
+            cap.color = m_document->getBodyColor(id);
+            if (computeSectionCap(shape, cuttingPlane, cap.positions))
+                m_caps.push_back(std::move(cap));
         } catch (...) {
             continue;
         }
@@ -167,7 +242,38 @@ void SectionView::update() {
 }
 
 void SectionView::render(const glm::mat4& view, const glm::mat4& projection) {
-    if (!m_enabled || m_lines.empty() || !m_program) return;
+    if (!m_enabled) return;
+
+    glm::mat4 mvpCap = projection * view;
+
+    // --- Filled caps first (depth-tested so walls in front still occlude) ---
+    if (m_capProgram && !m_caps.empty()) {
+        glUseProgram(m_capProgram);
+        glUniformMatrix4fv(m_capLocMVP, 1, GL_FALSE, glm::value_ptr(mvpCap));
+        glUniform3fv(m_capLocNormal, 1, glm::value_ptr(m_capNormal));
+
+        glEnable(GL_DEPTH_TEST);
+        glDisable(GL_CULL_FACE); // cap winding is not guaranteed toward camera
+
+        glBindVertexArray(m_capVao);
+        glBindBuffer(GL_ARRAY_BUFFER, m_capVbo);
+        for (const auto& cap : m_caps) {
+            glBufferData(GL_ARRAY_BUFFER,
+                         static_cast<GLsizeiptr>(cap.positions.size() * sizeof(float)),
+                         cap.positions.data(), GL_DYNAMIC_DRAW);
+            glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), nullptr);
+            glEnableVertexAttribArray(0);
+            glUniform3fv(m_capLocColor, 1, glm::value_ptr(cap.color));
+            glDrawArrays(GL_TRIANGLES, 0,
+                         static_cast<GLsizei>(cap.positions.size() / 3));
+        }
+        glBindVertexArray(0);
+    }
+
+    if (m_lines.empty() || !m_program) {
+        glUseProgram(0);
+        return;
+    }
 
     // Upload line data to VBO
     std::vector<float> vertices;

--- a/src/viewport/SectionView.cpp
+++ b/src/viewport/SectionView.cpp
@@ -252,22 +252,24 @@ void SectionView::render(const glm::mat4& view, const glm::mat4& projection) {
         glUniformMatrix4fv(m_capLocMVP, 1, GL_FALSE, glm::value_ptr(mvpCap));
         glUniform3fv(m_capLocNormal, 1, glm::value_ptr(m_capNormal));
 
+        const GLboolean cullWas = glIsEnabled(GL_CULL_FACE);
         glEnable(GL_DEPTH_TEST);
         glDisable(GL_CULL_FACE); // cap winding is not guaranteed toward camera
 
         glBindVertexArray(m_capVao);
         glBindBuffer(GL_ARRAY_BUFFER, m_capVbo);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), nullptr);
+        glEnableVertexAttribArray(0);
         for (const auto& cap : m_caps) {
             glBufferData(GL_ARRAY_BUFFER,
                          static_cast<GLsizeiptr>(cap.positions.size() * sizeof(float)),
                          cap.positions.data(), GL_DYNAMIC_DRAW);
-            glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), nullptr);
-            glEnableVertexAttribArray(0);
             glUniform3fv(m_capLocColor, 1, glm::value_ptr(cap.color));
             glDrawArrays(GL_TRIANGLES, 0,
                          static_cast<GLsizei>(cap.positions.size() / 3));
         }
         glBindVertexArray(0);
+        if (cullWas) glEnable(GL_CULL_FACE); // restore; do not leak state
     }
 
     if (m_lines.empty() || !m_program) {

--- a/src/viewport/SectionView.h
+++ b/src/viewport/SectionView.h
@@ -40,11 +40,28 @@ private:
     };
     std::vector<SectionLine> m_lines;
 
+    // Filled cross-section caps: without a cap a clipped solid looks hollow.
+    // One entry per intersected body, carrying its material colour.
+    struct CapMesh {
+        std::vector<float> positions; // x,y,z per vertex, TRIANGLES
+        glm::vec3 color;
+    };
+    std::vector<CapMesh> m_caps;
+    glm::vec3 m_capNormal = glm::vec3(0.0f, 0.0f, 1.0f); // cut-plane normal (world)
+
     unsigned int m_program = 0;
     unsigned int m_vao = 0;
     unsigned int m_vbo = 0;
     int m_locMVP = -1;
     int m_locColor = -1;
+
+    // Cap fill program (flat-shaded so the cut reads as solid material).
+    unsigned int m_capProgram = 0;
+    unsigned int m_capVao = 0;
+    unsigned int m_capVbo = 0;
+    int m_capLocMVP = -1;
+    int m_capLocColor = -1;
+    int m_capLocNormal = -1;
 
     bool compileShader(unsigned int& shader, unsigned int type, const char* source);
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(materializr_core STATIC
     ${CMAKE_SOURCE_DIR}/src/io/ProjectRecovery.cpp
     ${CMAKE_SOURCE_DIR}/src/core/Verbose.cpp
     ${CMAKE_SOURCE_DIR}/src/modeling/Unfold.cpp
+    ${CMAKE_SOURCE_DIR}/src/viewport/SectionCap.cpp
 )
 
 target_include_directories(materializr_core PUBLIC
@@ -121,6 +122,11 @@ target_link_libraries(materializr_core PUBLIC
 add_executable(test_document test_document.cpp)
 target_link_libraries(test_document PRIVATE materializr_core gtest gtest_main)
 add_test(NAME test_document COMMAND test_document)
+
+# test_section_cap — section-view cross-section cap geometry (issue #15)
+add_executable(test_section_cap test_section_cap.cpp)
+target_link_libraries(test_section_cap PRIVATE materializr_core gtest gtest_main)
+add_test(NAME test_section_cap COMMAND test_section_cap)
 
 # test_history
 add_executable(test_history test_history.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,7 +123,7 @@ add_executable(test_document test_document.cpp)
 target_link_libraries(test_document PRIVATE materializr_core gtest gtest_main)
 add_test(NAME test_document COMMAND test_document)
 
-# test_section_cap — section-view cross-section cap geometry (issue #15)
+# test_section_cap - section-view cross-section cap geometry (issue #15)
 add_executable(test_section_cap test_section_cap.cpp)
 target_link_libraries(test_section_cap PRIVATE materializr_core gtest gtest_main)
 add_test(NAME test_section_cap COMMAND test_section_cap)

--- a/tests/test_section_cap.cpp
+++ b/tests/test_section_cap.cpp
@@ -1,0 +1,75 @@
+// Section-view cap generation (fix for materializr-cad/materializr#15).
+// A section-clipped solid must show a filled cross-section cap, not a hollow
+// shell. computeSectionCap() builds the cap triangles from the body/plane
+// intersection; here we assert the cap area matches the true cross-section.
+
+#include "viewport/SectionCap.h"
+
+#include <gtest/gtest.h>
+
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Ax2.hxx>
+
+#include <cmath>
+#include <vector>
+
+using materializr::computeSectionCap;
+
+// Sum triangle areas from an (x,y,z per vertex, TRIANGLES) buffer.
+static double capArea(const std::vector<float>& p) {
+    double area = 0.0;
+    for (size_t i = 0; i + 9 <= p.size(); i += 9) {
+        const double ux = p[i + 3] - p[i], uy = p[i + 4] - p[i + 1], uz = p[i + 5] - p[i + 2];
+        const double vx = p[i + 6] - p[i], vy = p[i + 7] - p[i + 1], vz = p[i + 8] - p[i + 2];
+        const double nx = uy * vz - uz * vy;
+        const double ny = uz * vx - ux * vz;
+        const double nz = ux * vy - uy * vx;
+        area += 0.5 * std::sqrt(nx * nx + ny * ny + nz * nz);
+    }
+    return area;
+}
+
+// Solid 20mm cube cut at z=10 -> cap is the full 20x20 = 400 mm^2 face.
+TEST(SectionCap, SolidBoxCapEqualsCrossSection) {
+    TopoDS_Shape box = BRepPrimAPI_MakeBox(20.0, 20.0, 20.0).Shape();
+    gp_Pln plane(gp_Pnt(0, 0, 10), gp_Dir(0, 0, 1));
+
+    std::vector<float> pos;
+    ASSERT_TRUE(computeSectionCap(box, plane, pos));
+    ASSERT_FALSE(pos.empty());
+
+    for (size_t i = 0; i + 2 < pos.size(); i += 3)
+        EXPECT_NEAR(pos[i + 2], 10.0f, 1e-3f); // every cap vertex on the plane
+
+    EXPECT_NEAR(capArea(pos), 400.0, 1.0);
+}
+
+// Cube with a 5mm-radius bore -> cap is an annulus of 400 - pi*r^2.
+TEST(SectionCap, HollowBoxCapIsAnnulus) {
+    TopoDS_Shape box = BRepPrimAPI_MakeBox(20.0, 20.0, 20.0).Shape();
+    gp_Ax2 axis(gp_Pnt(10, 10, 0), gp_Dir(0, 0, 1));
+    TopoDS_Shape bore = BRepPrimAPI_MakeCylinder(axis, 5.0, 20.0).Shape();
+    TopoDS_Shape hollow = BRepAlgoAPI_Cut(box, bore).Shape();
+    gp_Pln plane(gp_Pnt(0, 0, 10), gp_Dir(0, 0, 1));
+
+    std::vector<float> pos;
+    ASSERT_TRUE(computeSectionCap(hollow, plane, pos));
+
+    const double expected = 400.0 - M_PI * 25.0;
+    EXPECT_NEAR(capArea(pos), expected, 2.0); // slack for arc tessellation
+}
+
+// Plane clear of the body -> no cap produced, buffer untouched.
+TEST(SectionCap, NoIntersectionNoCap) {
+    TopoDS_Shape box = BRepPrimAPI_MakeBox(20.0, 20.0, 20.0).Shape();
+    gp_Pln plane(gp_Pnt(0, 0, 30), gp_Dir(0, 0, 1));
+
+    std::vector<float> pos;
+    EXPECT_FALSE(computeSectionCap(box, plane, pos));
+    EXPECT_TRUE(pos.empty());
+}

--- a/tests/test_section_cap.cpp
+++ b/tests/test_section_cap.cpp
@@ -73,3 +73,23 @@ TEST(SectionCap, NoIntersectionNoCap) {
     EXPECT_FALSE(computeSectionCap(box, plane, pos));
     EXPECT_TRUE(pos.empty());
 }
+
+// Plane grazing a boundary face (no material removed) must NOT cap: the body
+// [0,20] on z sits entirely on one side of z=0 and z=20. Without the strict
+// straddle check the coplanar base/top face would be filled as a false cap
+// that z-fights the real face.
+TEST(SectionCap, TangentPlaneNoCap) {
+    TopoDS_Shape box = BRepPrimAPI_MakeBox(20.0, 20.0, 20.0).Shape();
+    std::vector<float> pos;
+
+    EXPECT_FALSE(computeSectionCap(box, gp_Pln(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), pos));
+    EXPECT_TRUE(pos.empty());
+    EXPECT_FALSE(computeSectionCap(box, gp_Pln(gp_Pnt(0, 0, 20), gp_Dir(0, 0, 1)), pos));
+    EXPECT_TRUE(pos.empty());
+}
+
+// NOTE: these area assertions cannot detect a kept-side sign flip. The cut face
+// is congruent for either half-space, so keeping +normal instead of -normal
+// yields the identical cap geometry (same area, same plane). The kept-side
+// convention is guarded by construction (refPnt = loc - normal) and reviewed
+// against the shader's discard sign, not by these tests.


### PR DESCRIPTION
## Summary

Section View clipped bodies with a fragment `discard` and drew no cap, so a solid body rendered as a hollow shell (#15). This adds a filled, lit cross-section cap so a solid reads as solid and only genuine voids read as hollow.

## Changes

- New `computeSectionCap()` (`src/viewport/SectionCap.cpp`, pure OCCT, no GL): intersects each body with the kept half-space (`BRepAlgoAPI_Common`), meshes it, and collects the planar faces coincident with the cut plane. A bounding-box straddle pre-check only proceeds when the plane strictly cuts material on both sides, so bodies the plane never touches cost nothing during an offset-slider drag, and a plane grazing a boundary face never fills that untouched face.
- `SectionView` renders the caps flat-lit and depth-tested beneath the existing section outline lines, via a small cap shader, in each body's material color.

## Tests

New `test_section_cap` (gtest): a solid 20mm cube caps at 400 mm^2 with every vertex on the plane; a bored cube caps as an annulus (400 - 25pi); planes clear of or tangent to the body produce no cap. Full suite 28/28.

## Notes

- Kept-side convention (`refPnt = loc - normal`) matches the shader discard (`dot > 0`).
- Verified visually (the previously hollow-looking Demo Box now shows a solid green cap) and taken through a three-reviewer adversarial pass; the second commit is the review hardening (straddle guard, exception rollback, GL state restore, em-dash cleanup).

Fixes #15
