### PR TITLE
Renderer: break depth ties between overlapping bodies

### DIFF
--- a/src/viewport/ShapeRenderer.cpp
+++ b/src/viewport/ShapeRenderer.cpp
@@ -468,8 +468,24 @@ void ShapeRenderer::render(const glm::mat4& view, const glm::mat4& projection,
     glUniform1i(m_meshLoc_headlight, m_lighting.headlight ? 1 : 0);
     glUniform1f(m_meshLoc_fillStrength, m_lighting.fill ? m_lighting.fillStrength : 0.0f);
 
-    for (const auto& mesh : m_meshes) {
+    // Coincident-face tie-break: overlapping bodies can share exactly coplanar
+    // faces (Extrude From leaves the new body's base on the source face), and
+    // equal depth values z-fight as a shimmering checkerboard. Push each body
+    // DEEPER the older it is, so the newest body wins such ties
+    // deterministically. Deeper, not nearer: edges are GL_LINES, which polygon
+    // offset cannot bias, so pulling a body's faces nearer would occlude its
+    // own edges. Both offset terms scale with the body's age rank: the
+    // constant term breaks ties head-on, and the slope term is required at
+    // grazing angles / deep zoom, where the two meshes tessellate the shared
+    // plane differently and their depth interpolation errors grow with the
+    // depth gradient - a constant-only offset re-fights there.
+    glEnable(GL_POLYGON_OFFSET_FILL);
+    const int slotCount = static_cast<int>(m_meshes.size());
+    for (int slot = 0; slot < slotCount; ++slot) {
+        const auto& mesh = m_meshes[slot];
         if (mesh.vertexCount == 0) continue; // vacant slot
+        const float rank = static_cast<float>(slotCount - 1 - slot);
+        glPolygonOffset(rank, 2.0f * rank);
         glUniformMatrix4fv(m_meshLoc_model, 1, GL_FALSE, glm::value_ptr(mesh.modelMatrix));
         glUniform3fv(m_meshLoc_objectColor, 1, glm::value_ptr(mesh.color));
         glUniform1i(m_meshLoc_selected, mesh.selected ? 1 : 0);
@@ -478,6 +494,8 @@ void ShapeRenderer::render(const glm::mat4& view, const glm::mat4& projection,
         glBindVertexArray(mesh.vao);
         glDrawArrays(GL_TRIANGLES, 0, mesh.vertexCount);
     }
+    glPolygonOffset(0.0f, 0.0f);
+    glDisable(GL_POLYGON_OFFSET_FILL);
 
     glBindVertexArray(0);
     glUseProgram(0);


### PR DESCRIPTION
## Summary

Overlapping bodies can share exactly coplanar faces (Extrude From leaves the new body's base on the source face). Equal depth values z-fight as a shimmering red/green checkerboard wherever the shared regions are visible, which reads as broken geometry. The geometry is valid; this is purely a rendering tie.

## Change

Apply `GL_POLYGON_OFFSET_FILL` in `ShapeRenderer`'s main pass, pushing each body deeper the older it is (`glPolygonOffset(rank, 2 * rank)` by body slot age), so the newest body wins coincidence ties deterministically.

- Deeper rather than nearer: edges are `GL_LINES`, which polygon offset cannot bias, so pulling a body's faces nearer would occlude its own edges.
- Both terms scale with age rank: the constant term breaks ties head-on; the slope-scaled term keeps them broken at grazing angles and deep zoom, where the two meshes tessellate the shared plane differently and depth interpolation error grows with the depth gradient.
- `GL_POLYGON_OFFSET_FILL` exists on GL ES too, so the Android build gets the same behavior.

## Verification

Reproduced the artifact (solid box + Extrude From its top face, -10mm, distinct colors): coincident walls checkerboarded before, render as a clean single color after, at normal views and deep zoom. Edges and selection outlines unaffected. A faint residual remains at extreme zoom-in on overlap regions - that is 24-bit depth precision exhaustion, common to CAD viewers, and resolving the overlap with a boolean removes it entirely.

## Notes

Known limitation: the tie winner is draw-order (newest body), not user-selectable. A tie between two solids occupying the same space has no correct answer; deterministic beats flicker.
