### PR TITLE
Fix macOS reporting no file-dialog program available

### DIFF
--- a/src/io/FileDialogs.cpp
+++ b/src/io/FileDialogs.cpp
@@ -278,6 +278,8 @@ bool FileDialogs::dialogsAvailable() {
     return true;           // SAF picker is always present
 #elif defined(_WIN32)
     return true;           // native comdlg
+#elif defined(__APPLE__)
+    return true;           // pfd shells out to osascript, always present on macOS
 #else
     // pfd shells out to one of these; scan PATH once for any of them.
     static int cached = -1;


### PR DESCRIPTION
## Summary
- `FileDialogs::dialogsAvailable()` only special-cased `MZ_MOBILE`/`_WIN32`; macOS fell into the Linux zenity/kdialog `$PATH` scan and always reported unavailable, showing "No file-dialog program found — install zenity/kdialog" on every Import/Export/Open/Save.
- pfd already backs macOS dialogs with `osascript`, which is always present, so macOS just needs its own branch returning `true`.

Fixes #18

## Test plan
- [x] Rebuilt on macOS, confirmed Import STL → Browse now opens the native osascript-backed picker instead of showing the toast
- [x] Confirmed Android (MZ_MOBILE) and Windows paths untouched (branch order unchanged, macOS branch added between them)