### PR TITLE
BrepIO: reject impossible section counts before BRepTools::Read (fixes #66)

### DIFF
--- a/src/io/BrepIO.cpp
+++ b/src/io/BrepIO.cpp
@@ -12,6 +12,11 @@
 #include <TopoDS_Iterator.hxx>
 #include <gp_Trsf.hxx>
 
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
@@ -59,12 +64,78 @@ int addShapeAsBodies(const TopoDS_Shape& shape, Document& doc, int& counter) {
     return added;
 }
 
+// Pre-scan guard against a length-prefix DoS in OCCT's BREP reader. The ASCII
+// BREP format is a run of section tables (Curves, Curve2ds, Surfaces, …) each
+// introduced by a "Keyword <count>" line, and BRepTools::Read trusts each
+// count — it reserves/reads that many records before validating anything. A
+// ~90-byte file whose header says "Curves 999999999" makes it spin/OOM for
+// many seconds, which neither OCC_CATCH_SIGNALS nor the try/catch below can
+// interrupt (it's a long allocation/read loop, not a signal or a throw). No
+// legitimate file can have a section count larger than its own byte size — a
+// single record is always several bytes on disk — so a count exceeding the
+// file length is provably fake. Reject those (and absurdly large files) up
+// front, before handing the path to the kernel reader.
+//
+// Returns false and fills `why` when the file should be refused; true = safe
+// to hand to BRepTools::Read (including genuinely-broken-but-bounded files,
+// which the reader itself rejects quickly and cleanly).
+bool brepHeaderCountsSane(const std::string& filePath, std::string& why) {
+    constexpr std::uintmax_t kMaxBytes = 512ull * 1024 * 1024; // 512 MB, as ProjectIO
+
+    std::ifstream in(filePath, std::ios::in | std::ios::binary);
+    if (!in.is_open()) return true; // let BRepTools::Read report the open error
+
+    in.seekg(0, std::ios::end);
+    std::streamoff endPos = in.tellg();
+    in.seekg(0, std::ios::beg);
+    if (endPos < 0) return true; // unseekable — nothing to pre-scan, let OCCT try
+    const std::uintmax_t size = static_cast<std::uintmax_t>(endPos);
+    if (size > kMaxBytes) {
+        why = "BREP file too large (> 512 MB) — refusing to load";
+        return false;
+    }
+
+    // The dangerous counts live on their own "Keyword <int>" lines in the
+    // header run. Scan line-by-line; a section count can never exceed the file
+    // size in bytes, so that's the reject threshold (generous — real records
+    // are far bigger than a byte, so this never trips a valid file).
+    static const char* kKeywords[] = {
+        "Locations", "Curve2ds", "Curves", "Polygon3D",
+        "PolygonOnTriangulations", "Surfaces", "Triangulations", "TShapes",
+    };
+    std::string line;
+    while (std::getline(in, line)) {
+        for (const char* kw : kKeywords) {
+            const std::size_t klen = std::char_traits<char>::length(kw);
+            if (line.compare(0, klen, kw) != 0) continue;
+            if (line.size() <= klen || line[klen] != ' ') continue;
+            // Parse the count token; a value beyond the file size is impossible.
+            std::istringstream ls(line.substr(klen + 1));
+            unsigned long long count = 0;
+            if (!(ls >> count)) break; // not a count line for this keyword
+            if (count > size) {
+                why = std::string("BREP header declares an impossible ") + kw +
+                      " count — refusing (likely a malformed/hostile file)";
+                return false;
+            }
+            break;
+        }
+    }
+    return true;
+}
+
 } // namespace
 
 ImportResult BrepIO::import(const std::string& filePath, Document& doc) {
     ImportResult result;
     try {
         OCC_CATCH_SIGNALS // kernel fault on a crafted file → the catch below
+        // Bound the untrusted length-prefixed section counts before the kernel
+        // reader trusts them (see brepHeaderCountsSane).
+        if (std::string why; !brepHeaderCountsSane(filePath, why)) {
+            result.errorMessage = why;
+            return result;
+        }
         TopoDS_Shape shape;
         BRep_Builder builder;
         if (!BRepTools::Read(shape, filePath.c_str(), builder)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -418,3 +418,9 @@ add_executable(test_blend_cut test_blend_cut.cpp)
 target_link_libraries(test_blend_cut PRIVATE materializr_core gtest gtest_main)
 add_test(NAME test_blend_cut COMMAND test_blend_cut)
 
+
+# test_brepio_dos — the BREP length-prefix DoS guard (impossible section count
+# rejected fast, valid file still round-trips, truncated file fails cleanly)
+add_executable(test_brepio_dos test_brepio_dos.cpp)
+target_link_libraries(test_brepio_dos PRIVATE materializr_core gtest gtest_main)
+add_test(NAME test_brepio_dos COMMAND test_brepio_dos)

--- a/tests/test_brepio_dos.cpp
+++ b/tests/test_brepio_dos.cpp
@@ -1,0 +1,89 @@
+// Regression test for the BREP length-prefix DoS: a tiny .brep file whose
+// header declares an impossible section count (e.g. "Curves 999999999") made
+// OCCT's BRepTools::Read spin/OOM for many seconds before the pre-scan guard
+// in BrepIO::import was added. The guard rejects any section count larger than
+// the file's own byte size (physically impossible for a real file) up front.
+//
+// If the guard regresses, ImpossibleCountIsRejectedFast doesn't just fail — it
+// hangs, and CTest's per-test timeout turns that into a red build, which is the
+// intended signal.
+
+#include "io/BrepIO.h"
+#include "core/Document.h"
+
+#include <gtest/gtest.h>
+
+#include <BRepPrimAPI_MakeBox.hxx>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+namespace {
+
+std::string tempPath(const char* name) {
+    const char* dir = std::getenv("TMPDIR");
+    std::string base = (dir && *dir) ? dir : "/tmp";
+    if (!base.empty() && base.back() != '/') base += '/';
+    return base + name;
+}
+
+void writeFile(const std::string& path, const std::string& text) {
+    std::ofstream f(path, std::ios::trunc | std::ios::binary);
+    ASSERT_TRUE(f.is_open()) << "cannot write " << path;
+    f << text;
+}
+
+} // namespace
+
+TEST(BrepIoDos, ImpossibleCountIsRejectedFast) {
+    const std::string path = tempPath("mz_test_brep_hugecount.brep");
+    // ~90 bytes, but the header claims ~1e9 curves — no real file can.
+    writeFile(path,
+              "DBRep_DrawableShape\n\n"
+              "CASCADE Topology V3, (c) Open Cascade\n"
+              "Locations 0\nCurve2ds 0\nCurves 999999999\n");
+
+    Document doc;
+    auto r = materializr::BrepIO::import(path, doc);
+    std::remove(path.c_str());
+
+    EXPECT_FALSE(r.success);
+    EXPECT_TRUE(doc.getAllBodyIds().empty());
+    // The message names the guard so a future refactor that drops it and lets
+    // the file fail elsewhere (or hang) is visible here.
+    EXPECT_NE(r.errorMessage.find("impossible"), std::string::npos)
+        << "expected the count-sanity guard to fire, got: " << r.errorMessage;
+}
+
+TEST(BrepIoDos, ValidFileStillRoundTrips) {
+    // Guard must not reject a legitimate file: export a real box, re-import it.
+    const std::string path = tempPath("mz_test_brep_valid.brep");
+    Document out;
+    out.addBody(BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape(), "box");
+    ASSERT_TRUE(materializr::BrepIO::exportFile(path, out).success);
+
+    Document in;
+    auto r = materializr::BrepIO::import(path, in);
+    std::remove(path.c_str());
+
+    EXPECT_TRUE(r.success) << r.errorMessage;
+    EXPECT_EQ(in.getAllBodyIds().size(), 1u);
+}
+
+TEST(BrepIoDos, TruncatedFileFailsCleanly) {
+    // A believable-but-truncated file (counts within the byte size) sails past
+    // the guard and is rejected by the reader itself — still no crash/hang.
+    const std::string path = tempPath("mz_test_brep_truncated.brep");
+    writeFile(path,
+              "DBRep_DrawableShape\n\n"
+              "CASCADE Topology V3, (c) Open Cascade\n"
+              "Locations 0\nCurve2ds 0\nCurves 2\n1 0 0 0 0 -1 0\n");
+
+    Document doc;
+    auto r = materializr::BrepIO::import(path, doc);
+    std::remove(path.c_str());
+
+    EXPECT_FALSE(r.success);
+    EXPECT_TRUE(doc.getAllBodyIds().empty());
+}


### PR DESCRIPTION
Fixes #66.

## Problem

OCCT's ASCII BREP reader trusts each `Keyword <count>` section header — it reserves/reads that many records before validating anything. A ~90-byte `.brep` whose header says `Curves 999999999` makes `BRepTools::Read` spin/OOM for many seconds (killed at >8 s in testing). `BrepIO::import`'s `OCC_CATCH_SIGNALS` and `try/catch` can't interrupt it — it's a long allocation/read loop, not a signal or a throw, so the catch block is never reached.

Same length-prefix DoS class as the STEP/IGES "no resource limits on untrusted exchange files" item; BREP has the identical gap. Surfaced by the new BREP import fuzzer while building its seed corpus.

## Fix

`brepHeaderCountsSane()` runs before `BRepTools::Read` and rejects the file if:
- any section count (`Locations`, `Curve2ds`, `Curves`, `Polygon3D`, `PolygonOnTriangulations`, `Surfaces`, `Triangulations`, `TShapes`) exceeds the file's own byte size — physically impossible for a real file, since every record is several bytes on disk; or
- the file is larger than 512 MB (matching `ProjectIO`'s cap).

A truncated-but-believable file (counts within the byte size) still passes through and the kernel reader rejects it quickly, exactly as today — only the provably-fake counts are cut, so no legitimate file is affected.

## Tests

`test_brepio_dos`:
- `ImpossibleCountIsRejectedFast` — the 90-byte / 1e9-count file is rejected in 0 ms (hung >8 s before). If the guard regresses this test hangs, and CTest's timeout turns that into a red build.
- `ValidFileStillRoundTrips` — a real box exported via `BrepIO::exportFile` re-imports to one body.
- `TruncatedFileFailsCleanly` — believable-but-truncated file fails cleanly, no crash/hang.

Full suite green (40/40, macOS arm64 Release).
