### PR TITLE
Sketch dimension tool (d): Onshape-style dimensions, reference by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ compile_commands.json
 Thumbs.db
 
 # Runtime-generated UI layout (written on first launch from the built-in default)
-imgui.ini
+imgui.ini*
 
 # Dependencies (fetched by CMake)
 third_party/imgui/

--- a/docs/superpowers/plans/2026-07-19-sketch-dimension-tool.md
+++ b/docs/superpowers/plans/2026-07-19-sketch-dimension-tool.md
@@ -1,0 +1,1270 @@
+# Sketch Dimension Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Onshape-style dimension tool in sketch mode, bound to `d`: click entities, place a label, type a value — creating driving constraints (distance, length, diameter, angle, point-to-line).
+
+**Architecture:** New `SketchToolMode::Dimension` state machine in `SketchTool` (picking + pair resolution, no mutations), a new solver constraint `DistancePointLine`, persisted label offsets on `Constraint`, and app-layer commit through `recordSketchMutation` reusing the existing `##DimEdit` popup for value entry.
+
+**Tech Stack:** C++17, ImGui, glm, OCCT (sketch plane only), GoogleTest + ctest, Unix Makefiles build in `build/`.
+
+**Spec:** `docs/superpowers/specs/2026-07-19-sketch-dimension-tool-design.md` — read it first.
+
+## Global Constraints
+
+- `ConstraintType` enum is **append-only** (serialization stores the int value). `DistancePointLine` goes after `Angle`, nothing reordered.
+- K-line format: new fields append at the END of the line; reader must accept 6-field legacy lines.
+- Repo root for all paths below: `materializr/` (the git repo). Build dir: `build/` (Unix Makefiles, already configured).
+- Build: `cmake --build build -j 8 --target <target>`; full: `cmake --build build -j 8`.
+- **ctest must run UNSANDBOXED** — sandboxed runs false-fail 5 file-IO suites on /tmp writes (see project memory).
+- Existing `Angle` constraint semantics: **signed** angle of line B relative to line A, radians, wrapped to [-π, π] (`SketchSolver.cpp` `case ConstraintType::Angle`). Match it exactly.
+- Existing UI convention: circle/arc dims display and edit as **diameter**, stored as radius in `Constraint::value`.
+- Commits: normal messages, no Claude trailer (project policy).
+
+---
+
+### Task 1: `DistancePointLine` constraint in the solver
+
+**Files:**
+- Modify: `src/modeling/SketchConstraints.h`
+- Modify: `src/modeling/SketchSolver.cpp` (three switch statements: `numEquations` in `solve()`, `computeError()`, `applyCorrection()`)
+- Create: `tests/test_sketch_dimension.cpp`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: `Sketch::addPoint(glm::vec2)`, `Sketch::addLine(int,int)`, `Sketch::addConstraint(const Constraint&)` (assigns id, returns it), `SketchSolver::solve(Sketch&, int maxIterations, double tolerance)`.
+- Produces: `ConstraintType::DistancePointLine` — entityA = point id, entityB = line id, value = perpendicular distance to the infinite line. Later tasks rely on this exact meaning.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_sketch_dimension.cpp`:
+
+```cpp
+// DistancePointLine: perpendicular distance from a point (entityA) to the
+// infinite line carried by a sketch line (entityB). Solver drives the point
+// and the line's endpoints apart/together along the line normal.
+
+#include "modeling/Sketch.h"
+#include "modeling/SketchSolver.h"
+
+#include <gtest/gtest.h>
+#include <glm/glm.hpp>
+#include <cmath>
+
+using materializr::Constraint;
+using materializr::ConstraintType;
+using materializr::Sketch;
+using materializr::SketchSolver;
+
+namespace {
+
+double pointLineDist(const Sketch& sk, int ptId, int lineId) {
+    const auto* p = sk.getPoint(ptId);
+    for (const auto& l : sk.getLines()) {
+        if (l.id != lineId) continue;
+        const auto* a = sk.getPoint(l.startPointId);
+        const auto* b = sk.getPoint(l.endPointId);
+        glm::vec2 d = b->pos - a->pos;
+        glm::vec2 r = p->pos - a->pos;
+        return std::abs(d.x * r.y - d.y * r.x) / glm::length(d);
+    }
+    return -1.0;
+}
+
+Constraint makeDPL(int ptId, int lineId, double value) {
+    Constraint c{};
+    c.id = 0;
+    c.type = ConstraintType::DistancePointLine;
+    c.entityA = ptId;
+    c.entityB = lineId;
+    c.value = value;
+    return c;
+}
+
+} // namespace
+
+TEST(DistancePointLine, ConvergesToTarget) {
+    Sketch sk;
+    int a = sk.addPoint({0.0f, 0.0f});
+    int b = sk.addPoint({10.0f, 0.0f});
+    int ln = sk.addLine(a, b);
+    int p = sk.addPoint({5.0f, 3.0f});
+    sk.addConstraint(makeDPL(p, ln, 7.0));
+
+    SketchSolver solver;
+    EXPECT_TRUE(solver.solve(sk, 500, 1e-4));
+    EXPECT_NEAR(pointLineDist(sk, p, ln), 7.0, 1e-3);
+}
+
+TEST(DistancePointLine, DegenerateLineDoesNotNaN) {
+    Sketch sk;
+    int a = sk.addPoint({2.0f, 2.0f});
+    int b = sk.addPoint({2.0f, 2.0f}); // zero-length line
+    int ln = sk.addLine(a, b);
+    int p = sk.addPoint({5.0f, 3.0f});
+    sk.addConstraint(makeDPL(p, ln, 4.0));
+
+    SketchSolver solver;
+    solver.solve(sk, 100, 1e-4); // must not crash or NaN, return value unspecified
+    for (const auto& pt : sk.getPoints()) {
+        EXPECT_TRUE(std::isfinite(pt.pos.x));
+        EXPECT_TRUE(std::isfinite(pt.pos.y));
+    }
+}
+
+TEST(DistancePointLine, MissingEntitiesAreInert) {
+    Sketch sk;
+    int p = sk.addPoint({1.0f, 1.0f});
+    sk.addConstraint(makeDPL(p, 9999, 4.0)); // no such line
+    SketchSolver solver;
+    solver.solve(sk, 50, 1e-4);
+    EXPECT_NEAR(sk.getPoint(p)->pos.x, 1.0f, 1e-6);
+    EXPECT_NEAR(sk.getPoint(p)->pos.y, 1.0f, 1e-6);
+}
+```
+
+Register in `tests/CMakeLists.txt` (append at the end, matching neighbors):
+
+```cmake
+# test_sketch_dimension — DistancePointLine solver, dimension pair resolution,
+# and K-line label-offset persistence (Onshape-style dimension tool).
+add_executable(test_sketch_dimension test_sketch_dimension.cpp)
+target_link_libraries(test_sketch_dimension PRIVATE materializr_core gtest gtest_main)
+add_test(NAME test_sketch_dimension COMMAND test_sketch_dimension)
+```
+
+- [ ] **Step 2: Run tests, verify they fail to compile**
+
+Run: `cmake --build build -j 8 --target test_sketch_dimension`
+Expected: compile error — `DistancePointLine` is not a member of `ConstraintType`.
+
+- [ ] **Step 3: Add the enum value and implement the solver cases**
+
+`src/modeling/SketchConstraints.h` — append to the enum (comment style matches neighbors):
+
+```cpp
+    Concentric,    // two circles/arcs share same center
+    Angle,         // fixed angle (radians) between two lines
+    DistancePointLine // fixed perpendicular distance from a point to a line's infinite carrier
+```
+
+Do NOT add the label-offset fields yet (Task 2).
+
+`src/modeling/SketchSolver.cpp` — three additions:
+
+1. In `solve()`'s `numEquations` switch:
+
+```cpp
+            case ConstraintType::DistancePointLine:
+                numEquations += 1;
+                break;
+```
+
+2. In `computeError()` (after the `Angle` case):
+
+```cpp
+        case ConstraintType::DistancePointLine: {
+            // entityA = point id, entityB = line id. Distance is to the
+            // line's INFINITE carrier, matching how CAD dimensions read.
+            const SketchPoint* p = sketch.getPoint(c.entityA);
+            if (!p) return 0.0;
+            for (const auto& line : sketch.getLines()) {
+                if (line.id != c.entityB) continue;
+                const SketchPoint* a = sketch.getPoint(line.startPointId);
+                const SketchPoint* b = sketch.getPoint(line.endPointId);
+                if (!a || !b) return 0.0;
+                glm::vec2 dir = b->pos - a->pos;
+                float len = glm::length(dir);
+                if (len < 1e-10f) return 0.0; // degenerate line: inert, no NaN
+                glm::vec2 rel = p->pos - a->pos;
+                double dist = std::abs(static_cast<double>(dir.x) * rel.y -
+                                       static_cast<double>(dir.y) * rel.x) / len;
+                return dist - c.value;
+            }
+            return 0.0;
+        }
+```
+
+3. In `applyCorrection()` (after the `Angle` case; split correction between the point and the line, mirroring the `Distance` case):
+
+```cpp
+        case ConstraintType::DistancePointLine: {
+            const SketchPoint* p = sketch.getPoint(c.entityA);
+            if (!p) return;
+            for (const auto& line : sketch.getLines()) {
+                if (line.id != c.entityB) continue;
+                const SketchPoint* a = sketch.getPoint(line.startPointId);
+                const SketchPoint* b = sketch.getPoint(line.endPointId);
+                if (!a || !b) return;
+                glm::vec2 dir = b->pos - a->pos;
+                float len = glm::length(dir);
+                if (len < 1e-10f) return;
+                dir /= len;
+                glm::vec2 n(-dir.y, dir.x); // unit normal
+                float s = glm::dot(p->pos - a->pos, n); // signed distance
+                if (s < 0.0f) { n = -n; s = -s; }       // n points line → point
+                float corr = (static_cast<float>(c.value) - s) * 0.5f;
+                sketch.movePoint(c.entityA, p->pos + n * corr);
+                sketch.movePoint(line.startPointId, a->pos - n * corr);
+                sketch.movePoint(line.endPointId,   b->pos - n * corr);
+                return;
+            }
+            break;
+        }
+```
+
+- [ ] **Step 4: Build and run the tests**
+
+Run: `cmake --build build -j 8 --target test_sketch_dimension && ./build/tests/test_sketch_dimension`
+(If the test binary lands elsewhere, find it: `find build -name test_sketch_dimension -type f`.)
+Expected: all 3 tests PASS.
+
+- [ ] **Step 5: Orphan-cleanup sanity check (no code expected)**
+
+`Sketch::pruneOrphanPoints()` already drops any constraint whose `entityA`/`entityB` id vanished (generic id check over points AND elements — `src/modeling/Sketch.cpp:655`). Confirm by reading that function; `DistancePointLine` needs no special case. If that generic check has changed, add the new type to it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/modeling/SketchConstraints.h src/modeling/SketchSolver.cpp tests/test_sketch_dimension.cpp tests/CMakeLists.txt
+git commit -m "sketch solver: DistancePointLine constraint (point to infinite line)"
+```
+
+---
+
+### Task 2: Label offsets on `Constraint` + K-line persistence
+
+**Files:**
+- Modify: `src/modeling/SketchConstraints.h`
+- Modify: `src/io/ProjectIO.cpp` (writer ~line 328, reader ~line 650)
+- Modify: `tests/test_sketch_dimension.cpp` (add roundtrip tests)
+
+**Interfaces:**
+- Consumes: `ProjectIO::save(const std::string&, const Document&, const ProjectHistory* = nullptr)`, `ProjectIO::load(const std::string&, Document&, ProjectHistory* = nullptr)` (`src/io/ProjectIO.h:61-66`), `Document::addSketch(std::shared_ptr<Sketch>, const std::string&)`, `Document::getSketch(int)`.
+- Produces: `Constraint::labelOffX` / `labelOffY` (`double`, default 0.0; sketch-space label offset from the auto anchor; `0,0` = auto placement). K-line format `K id type eA eB value valueY labelOffX labelOffY`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_sketch_dimension.cpp`:
+
+```cpp
+#include "core/Document.h"
+#include "io/ProjectIO.h"
+
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <sstream>
+
+using materializr::ProjectIO;
+
+namespace {
+
+std::string tmpProjectPath(const char* name) {
+    const char* t = std::getenv("TMPDIR");
+    std::string dir = t ? t : "/tmp";
+    if (!dir.empty() && dir.back() != '/') dir += '/';
+    return dir + name;
+}
+
+} // namespace
+
+TEST(DimensionPersistence, KLineRoundTripsTypeAndLabelOffsets) {
+    Document doc;
+    auto sk = std::make_shared<Sketch>();
+    int a = sk->addPoint({0.0f, 0.0f});
+    int b = sk->addPoint({10.0f, 0.0f});
+    int ln = sk->addLine(a, b);
+    int p = sk->addPoint({5.0f, 3.0f});
+    Constraint c{};
+    c.type = ConstraintType::DistancePointLine;
+    c.entityA = p;
+    c.entityB = ln;
+    c.value = 3.0;
+    c.labelOffX = 1.5;
+    c.labelOffY = -2.25;
+    sk->addConstraint(c);
+    doc.addSketch(sk, "dim-test");
+
+    std::string path = tmpProjectPath("dim_roundtrip.mzr");
+    ASSERT_TRUE(ProjectIO::save(path, doc).success);
+
+    Document loaded;
+    ASSERT_TRUE(ProjectIO::load(path, loaded).success);
+    std::remove(path.c_str());
+
+    // First (only) sketch in the loaded doc.
+    auto ids = loaded.getSketchIds();
+    ASSERT_EQ(ids.size(), 1u);
+    auto lsk = loaded.getSketch(ids[0]);
+    ASSERT_TRUE(lsk);
+    ASSERT_EQ(lsk->getConstraints().size(), 1u);
+    const Constraint& lc = lsk->getConstraints()[0];
+    EXPECT_EQ(lc.type, ConstraintType::DistancePointLine);
+    EXPECT_DOUBLE_EQ(lc.value, 3.0);
+    EXPECT_DOUBLE_EQ(lc.labelOffX, 1.5);
+    EXPECT_DOUBLE_EQ(lc.labelOffY, -2.25);
+}
+
+TEST(DimensionPersistence, LegacySixFieldKLineDefaultsOffsetsToZero) {
+    // Save with the new writer, then truncate every K line back to the legacy
+    // 6-field form and reload — offsets must default to 0, load must succeed.
+    Document doc;
+    auto sk = std::make_shared<Sketch>();
+    int a = sk->addPoint({0.0f, 0.0f});
+    int b = sk->addPoint({4.0f, 0.0f});
+    sk->addLine(a, b);
+    Constraint c{};
+    c.type = ConstraintType::Distance;
+    c.entityA = a;
+    c.entityB = b;
+    c.value = 4.0;
+    c.labelOffX = 9.0; // will be stripped below
+    c.labelOffY = 9.0;
+    sk->addConstraint(c);
+    doc.addSketch(sk, "legacy");
+
+    std::string path = tmpProjectPath("dim_legacy.mzr");
+    ASSERT_TRUE(ProjectIO::save(path, doc).success);
+
+    // Strip trailing fields from K lines: keep "K id type eA eB value valueY".
+    std::ifstream in(path);
+    std::stringstream out;
+    std::string line;
+    while (std::getline(in, line)) {
+        if (line.rfind("K ", 0) == 0) {
+            std::istringstream ls(line);
+            std::string tok, kept;
+            for (int i = 0; i < 7 && (ls >> tok); ++i) { // "K" + 6 fields
+                if (i) kept += ' ';
+                kept += tok;
+            }
+            out << kept << '\n';
+        } else {
+            out << line << '\n';
+        }
+    }
+    in.close();
+    std::ofstream ow(path, std::ios::trunc);
+    ow << out.str();
+    ow.close();
+
+    Document loaded;
+    ASSERT_TRUE(ProjectIO::load(path, loaded).success);
+    std::remove(path.c_str());
+    auto lsk = loaded.getSketch(loaded.getSketchIds()[0]);
+    ASSERT_EQ(lsk->getConstraints().size(), 1u);
+    EXPECT_DOUBLE_EQ(lsk->getConstraints()[0].labelOffX, 0.0);
+    EXPECT_DOUBLE_EQ(lsk->getConstraints()[0].labelOffY, 0.0);
+}
+```
+
+Note: if `Document::getSketchIds()` doesn't exist under that name, find the real accessor with `grep -n "getSketchIds\|sketchIds\|getAllSketch" src/core/Document.h` and use it; keep the rest of the test identical.
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `cmake --build build -j 8 --target test_sketch_dimension && ./build/tests/test_sketch_dimension --gtest_filter='DimensionPersistence.*'`
+Expected: FAIL — `labelOffX` not a member (compile), then after Step 3's header change, offsets not persisted (runtime).
+
+- [ ] **Step 3: Implement**
+
+`src/modeling/SketchConstraints.h`, inside `struct Constraint` after `valueY`:
+
+```cpp
+    // Sketch-space offset of the dimension label from its auto-computed
+    // anchor. (0,0) = legacy auto placement (pre-offset files and constraints
+    // created without explicit label placement).
+    double labelOffX = 0.0;
+    double labelOffY = 0.0;
+```
+
+`src/io/ProjectIO.cpp` writer (~line 328) — the K line becomes:
+
+```cpp
+        for (const auto& c : cns) {
+            ofs << "K " << c.id << " " << static_cast<int>(c.type) << " "
+                << c.entityA << " " << c.entityB << " "
+                << c.value << " " << c.valueY << " "
+                << c.labelOffX << " " << c.labelOffY << "\n";
+        }
+```
+
+Update the comment above it: the K line carries 8 fields, trailing two are label offsets, readers of older builds ignore trailing tokens.
+
+`src/io/ProjectIO.cpp` reader (~line 655) — after the existing extraction:
+
+```cpp
+                s >> t >> c.id >> tval >> c.entityA >> c.entityB >> c.value >> c.valueY;
+                c.type = static_cast<ConstraintType>(tval);
+                // Label offsets are trailing optional fields (since the
+                // dimension tool); legacy 6-field K lines default to auto
+                // placement.
+                if (!(s >> c.labelOffX >> c.labelOffY)) {
+                    c.labelOffX = 0.0;
+                    c.labelOffY = 0.0;
+                }
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `./build/tests/test_sketch_dimension`
+Expected: all tests PASS (Task 1's included).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modeling/SketchConstraints.h src/io/ProjectIO.cpp tests/test_sketch_dimension.cpp
+git commit -m "sketch: persist dimension label offsets on constraints (K-line v2)"
+```
+
+---
+
+### Task 3: Dimension mode state machine in `SketchTool`
+
+**Files:**
+- Modify: `src/modeling/SketchTool.h` (mode enum, new public types + API)
+- Modify: `src/modeling/SketchTool.cpp` (mode dispatch in `onMouseDown`/`onMouseMove`/`onCancel`, new methods)
+- Modify: `tests/test_sketch_dimension.cpp` (pair-resolution tests)
+
+**Interfaces:**
+- Consumes: `ConstraintType::DistancePointLine` (Task 1), Sketch accessors, `findCoincidentPoint`.
+- Produces (later tasks call these exact names):
+
+```cpp
+enum class SketchToolMode { None, Select, Line, Circle, Rectangle, Arc, Spline,
+                            Polygon, Trim, Text, Svg, Mirror, Dimension }; // Dimension appended
+
+enum class DimEntityKind { None, Point, Line, Circle, Arc };
+struct DimPick { DimEntityKind kind = DimEntityKind::None; int id = -1; };
+
+// A pick set resolved into the constraint it would create. measured is the
+// current geometry value: mm for distances, RADIUS in mm for Radius (UI
+// doubles it for display), SIGNED radians for Angle (line B rel. line A).
+struct PendingDimension {
+    ConstraintType type = ConstraintType::Distance;
+    int entityA = -1, entityB = -1;
+    double measured = 0.0;
+    bool valid = false;
+};
+
+enum class DimPhase { PickFirst, PickSecondOrPlace, PlaceLabel };
+
+// on SketchTool, public:
+DimPhase getDimPhase() const;
+DimPick getDimPickA() const;
+const PendingDimension& getPendingDimension() const;
+glm::vec2 getDimLabelPos() const;      // valid when dimReadyToCommit()
+bool dimReadyToCommit() const;         // label placed; app commits + calls clearDimState()
+void clearDimState();                  // back to PickFirst, pending invalidated
+DimPick dimHitTest(glm::vec2 pos) const; // hover highlight for the viewport
+static PendingDimension resolveDimension(const Sketch& sk, DimPick a, DimPick b);
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_sketch_dimension.cpp`:
+
+```cpp
+#include "modeling/SketchTool.h"
+
+using materializr::DimEntityKind;
+using materializr::DimPick;
+using materializr::PendingDimension;
+using materializr::SketchTool;
+
+namespace {
+
+// 10-unit horizontal line at y=0 and a second line at `deg` degrees from it,
+// plus a free point at (5,3). Returns ids via out-params.
+struct DimFixture {
+    Sketch sk;
+    int pA, pB, lnAB;      // horizontal line
+    int pC, pD, lnCD;      // rotated line
+    int pFree;
+    explicit DimFixture(float deg) {
+        pA = sk.addPoint({0.0f, 0.0f});
+        pB = sk.addPoint({10.0f, 0.0f});
+        lnAB = sk.addLine(pA, pB);
+        float r = deg * 3.14159265358979f / 180.0f;
+        pC = sk.addPoint({0.0f, 5.0f});
+        pD = sk.addPoint({10.0f * std::cos(r), 5.0f + 10.0f * std::sin(r)});
+        lnCD = sk.addLine(pC, pD);
+        pFree = sk.addPoint({5.0f, 3.0f});
+    }
+};
+
+DimPick pick(DimEntityKind k, int id) { return DimPick{k, id}; }
+
+} // namespace
+
+TEST(DimensionResolve, CircleAloneIsRadius) {
+    Sketch sk;
+    int c = sk.addPoint({0.0f, 0.0f});
+    int ci = sk.addCircle(c, 6.5);
+    auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Circle, ci), DimPick{});
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::Radius);
+    EXPECT_EQ(r.entityA, ci);
+    EXPECT_NEAR(r.measured, 6.5, 1e-9);
+}
+
+TEST(DimensionResolve, LineAloneIsEndpointDistance) {
+    DimFixture f(30.0f);
+    auto r = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Line, f.lnAB), DimPick{});
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::Distance);
+    EXPECT_EQ(r.entityA, f.pA);
+    EXPECT_EQ(r.entityB, f.pB);
+    EXPECT_NEAR(r.measured, 10.0, 1e-6);
+}
+
+TEST(DimensionResolve, PointPointIsDistance) {
+    DimFixture f(30.0f);
+    auto r = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Point, f.pA),
+                                          pick(DimEntityKind::Point, f.pFree));
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::Distance);
+    EXPECT_NEAR(r.measured, std::sqrt(25.0 + 9.0), 1e-6);
+}
+
+TEST(DimensionResolve, PointLineEitherOrderIsDistancePointLine) {
+    DimFixture f(30.0f);
+    auto r1 = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Point, f.pFree),
+                                           pick(DimEntityKind::Line, f.lnAB));
+    auto r2 = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Line, f.lnAB),
+                                           pick(DimEntityKind::Point, f.pFree));
+    for (const auto& r : {r1, r2}) {
+        ASSERT_TRUE(r.valid);
+        EXPECT_EQ(r.type, ConstraintType::DistancePointLine);
+        EXPECT_EQ(r.entityA, f.pFree);
+        EXPECT_EQ(r.entityB, f.lnAB);
+        EXPECT_NEAR(r.measured, 3.0, 1e-6);
+    }
+}
+
+TEST(DimensionResolve, ParallelLinesGiveDistance_NonParallelGiveAngle) {
+    DimFixture par(0.5f);   // inside the 1° parallel threshold
+    auto rp = SketchTool::resolveDimension(par.sk, pick(DimEntityKind::Line, par.lnAB),
+                                           pick(DimEntityKind::Line, par.lnCD));
+    ASSERT_TRUE(rp.valid);
+    EXPECT_EQ(rp.type, ConstraintType::DistancePointLine);
+    EXPECT_EQ(rp.entityA, par.pC);   // second line's start point
+    EXPECT_EQ(rp.entityB, par.lnAB); // measured against the first line
+
+    DimFixture ang(30.0f);
+    auto ra = SketchTool::resolveDimension(ang.sk, pick(DimEntityKind::Line, ang.lnAB),
+                                           pick(DimEntityKind::Line, ang.lnCD));
+    ASSERT_TRUE(ra.valid);
+    EXPECT_EQ(ra.type, ConstraintType::Angle);
+    EXPECT_EQ(ra.entityA, ang.lnAB);
+    EXPECT_EQ(ra.entityB, ang.lnCD);
+    EXPECT_NEAR(ra.measured, 30.0 * 3.14159265358979 / 180.0, 1e-4); // signed, B rel A
+}
+
+TEST(DimensionResolve, InvalidCombosAreInvalid) {
+    Sketch sk;
+    int c = sk.addPoint({0.0f, 0.0f});
+    int ci = sk.addCircle(c, 2.0);
+    int p = sk.addPoint({5.0f, 0.0f});
+    // circle + point is out of scope (spec non-goal)
+    auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Circle, ci),
+                                          pick(DimEntityKind::Point, p));
+    EXPECT_FALSE(r.valid);
+    // lone point
+    auto r2 = SketchTool::resolveDimension(sk, pick(DimEntityKind::Point, p), DimPick{});
+    EXPECT_FALSE(r2.valid);
+    // dangling id
+    auto r3 = SketchTool::resolveDimension(sk, pick(DimEntityKind::Line, 9999), DimPick{});
+    EXPECT_FALSE(r3.valid);
+}
+```
+
+Note on `resolveDimension` line-vs-line normalization: the tests pin **first-picked line = entityA / reference**; for the parallel case entityA is the SECOND line's start point measured against the FIRST line (`entityB` = first line id)… careful: `DistancePointLine` defines entityA = point, entityB = line. The test above encodes: pair (lineAB first, lineCD second) → point = `lnCD`'s start (`pC`), line = `lnAB`. That matches the spec ("first line's start point ↔ second line") mirrored — **the test is the source of truth here: point from the second-picked line, measured to the first-picked line**, which keeps the first pick as the reference entity for both the parallel and angle branches. (Deviation from spec wording, same geometry — note it in the commit message.)
+
+- [ ] **Step 2: Run tests, verify they fail to compile**
+
+Run: `cmake --build build -j 8 --target test_sketch_dimension`
+Expected: compile error — `resolveDimension` / `DimPick` not declared.
+
+- [ ] **Step 3: Implement in SketchTool**
+
+`src/modeling/SketchTool.h`:
+- Append `Dimension` to `SketchToolMode`.
+- Add the `DimEntityKind` / `DimPick` / `PendingDimension` / `DimPhase` declarations (namespace scope, before `class SketchTool`) exactly as in **Interfaces** above.
+- Public members on `SketchTool` exactly as in **Interfaces**.
+- Private state:
+
+```cpp
+    // --- Dimension tool state ---
+    DimPhase m_dimPhase = DimPhase::PickFirst;
+    DimPick m_dimPickA;
+    PendingDimension m_dimPending;
+    glm::vec2 m_dimLabelPos{0.0f};
+    bool m_dimReady = false;
+    DimPick hitTestDimEntity(glm::vec2 pos) const;
+    void handleDimensionTool(glm::vec2 pos);
+```
+
+`src/modeling/SketchTool.cpp`:
+
+1. `setMode()`: entering or leaving `Dimension` calls `clearDimState()`.
+
+2. `onMouseDown()` dispatch: add `case SketchToolMode::Dimension: handleDimensionTool(pos); break;` (use the RAW cursor like Trim — no snapping; see the comment at the top of `onMouseDown`).
+
+3. `onMouseMove()`: in Dimension mode just record `m_currentPos = pos;` (the viewport reads it for the ghost label) and return before snapping logic.
+
+4. `onCancel()`: in Dimension mode — if `m_dimPhase != DimPhase::PickFirst || m_dimReady`, `clearDimState()`; else `setMode(SketchToolMode::Select)`.
+
+5. Hit test — same priority and tolerance as `handleSelectTool` (point → line → circle/arc, `tol = std::max(m_gridStep * 0.5f, 0.5f) * snapScale()`); factor the shared scan or duplicate it (~40 lines), returning `DimPick`:
+
+```cpp
+DimPick SketchTool::hitTestDimEntity(glm::vec2 pos) const {
+    DimPick out;
+    if (!m_sketch) return out;
+    int nearPt = findCoincidentPoint(pos, -1);
+    if (nearPt >= 0) {
+        // Text glyph geometry is not dimensionable.
+        const SketchPoint* p = m_sketch->getPoint(nearPt);
+        if (p && !p->fromText) { out = {DimEntityKind::Point, nearPt}; }
+        return out;
+    }
+    const float tol = std::max(m_gridStep * 0.5f, 0.5f) * snapScale();
+    // Lines (segment distance), skipping fromText — same math as handleSelectTool.
+    float bestD = 0.0f; int bestLine = -1;
+    for (const auto& l : m_sketch->getLines()) {
+        if (l.fromText) continue;
+        const SketchPoint* a = m_sketch->getPoint(l.startPointId);
+        const SketchPoint* b = m_sketch->getPoint(l.endPointId);
+        if (!a || !b) continue;
+        glm::vec2 ab = b->pos - a->pos;
+        float len2 = glm::dot(ab, ab);
+        if (len2 < 1e-12f) continue;
+        float t = glm::clamp(glm::dot(pos - a->pos, ab) / len2, 0.0f, 1.0f);
+        float d = glm::distance(a->pos + ab * t, pos);
+        if (d < tol && (bestLine < 0 || d < bestD)) { bestLine = l.id; bestD = d; }
+    }
+    if (bestLine >= 0) return {DimEntityKind::Line, bestLine};
+    // Circle then arc perimeters — same as handleSelectTool.
+    float bestCd = 0.0f; int bestCircle = -1;
+    for (const auto& c : m_sketch->getCircles()) {
+        const SketchPoint* ctr = m_sketch->getPoint(c.centerPointId);
+        if (!ctr) continue;
+        float d = std::abs(glm::distance(pos, ctr->pos) - static_cast<float>(c.radius));
+        if (d < tol && (bestCircle < 0 || d < bestCd)) { bestCircle = c.id; bestCd = d; }
+    }
+    if (bestCircle >= 0) return {DimEntityKind::Circle, bestCircle};
+    float bestAd = 0.0f; int bestArc = -1;
+    for (const auto& a : m_sketch->getArcs()) {
+        const SketchPoint* ctr = m_sketch->getPoint(a.centerPointId);
+        if (!ctr) continue;
+        float d = std::abs(glm::distance(pos, ctr->pos) - static_cast<float>(a.radius));
+        if (d < tol && (bestArc < 0 || d < bestAd)) { bestArc = a.id; bestAd = d; }
+    }
+    if (bestArc >= 0) return {DimEntityKind::Arc, bestArc};
+    return out;
+}
+```
+
+6. State machine:
+
+```cpp
+void SketchTool::handleDimensionTool(glm::vec2 pos) {
+    if (!m_sketch) return;
+    m_currentPos = pos;
+    switch (m_dimPhase) {
+        case DimPhase::PickFirst: {
+            DimPick hit = hitTestDimEntity(pos);
+            if (hit.kind == DimEntityKind::None) return;
+            if (hit.kind == DimEntityKind::Circle || hit.kind == DimEntityKind::Arc) {
+                m_dimPending = resolveDimension(*m_sketch, hit, DimPick{});
+                if (m_dimPending.valid) { m_dimPickA = hit; m_dimPhase = DimPhase::PlaceLabel; }
+                return;
+            }
+            m_dimPickA = hit;
+            if (hit.kind == DimEntityKind::Line)
+                m_dimPending = resolveDimension(*m_sketch, hit, DimPick{}); // tentative length
+            else
+                m_dimPending = PendingDimension{}; // lone point: no dim yet
+            m_dimPhase = DimPhase::PickSecondOrPlace;
+            return;
+        }
+        case DimPhase::PickSecondOrPlace: {
+            DimPick hit = hitTestDimEntity(pos);
+            if (hit.kind != DimEntityKind::None) {
+                if (hit.kind == m_dimPickA.kind && hit.id == m_dimPickA.id) return; // same entity
+                PendingDimension pair = resolveDimension(*m_sketch, m_dimPickA, hit);
+                if (pair.valid) { m_dimPending = pair; m_dimPhase = DimPhase::PlaceLabel; }
+                return; // invalid combo: ignore the click, picks unchanged
+            }
+            // Empty space: places the tentative single-entity dim (line length).
+            if (m_dimPending.valid) { m_dimLabelPos = pos; m_dimReady = true; }
+            return; // lone point + empty space: no-op, pick stays pending
+        }
+        case DimPhase::PlaceLabel: {
+            m_dimLabelPos = pos;
+            m_dimReady = true;
+            return;
+        }
+    }
+}
+
+void SketchTool::clearDimState() {
+    m_dimPhase = DimPhase::PickFirst;
+    m_dimPickA = DimPick{};
+    m_dimPending = PendingDimension{};
+    m_dimReady = false;
+}
+```
+
+7. `resolveDimension` (static, pure):
+
+```cpp
+PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPick b) {
+    PendingDimension out;
+    auto lineById = [&sk](int id) -> const SketchLine* {
+        for (const auto& l : sk.getLines()) if (l.id == id) return &l;
+        return nullptr;
+    };
+    auto lineEnds = [&sk, &lineById](int id, glm::vec2& s, glm::vec2& e) {
+        const SketchLine* l = lineById(id);
+        if (!l) return false;
+        const SketchPoint* sp = sk.getPoint(l->startPointId);
+        const SketchPoint* ep = sk.getPoint(l->endPointId);
+        if (!sp || !ep) return false;
+        s = sp->pos; e = ep->pos;
+        return true;
+    };
+    auto perpDist = [](glm::vec2 p, glm::vec2 s, glm::vec2 e) -> double {
+        glm::vec2 d = e - s;
+        float len = glm::length(d);
+        if (len < 1e-10f) return -1.0;
+        glm::vec2 r = p - s;
+        return std::abs(static_cast<double>(d.x) * r.y -
+                        static_cast<double>(d.y) * r.x) / len;
+    };
+
+    // Single-entity dims.
+    if (b.kind == DimEntityKind::None) {
+        if (a.kind == DimEntityKind::Circle) {
+            for (const auto& c : sk.getCircles())
+                if (c.id == a.id) { out = {ConstraintType::Radius, a.id, -1, c.radius, true}; break; }
+            return out;
+        }
+        if (a.kind == DimEntityKind::Arc) {
+            for (const auto& ar : sk.getArcs())
+                if (ar.id == a.id) { out = {ConstraintType::Radius, a.id, -1, ar.radius, true}; break; }
+            return out;
+        }
+        if (a.kind == DimEntityKind::Line) {
+            const SketchLine* l = lineById(a.id);
+            glm::vec2 s, e;
+            if (l && lineEnds(a.id, s, e))
+                out = {ConstraintType::Distance, l->startPointId, l->endPointId,
+                       static_cast<double>(glm::distance(s, e)), true};
+            return out;
+        }
+        return out; // lone point: invalid
+    }
+
+    // Normalize point-first for the mixed pair.
+    if (a.kind == DimEntityKind::Line && b.kind == DimEntityKind::Point) std::swap(a, b);
+
+    if (a.kind == DimEntityKind::Point && b.kind == DimEntityKind::Point) {
+        const SketchPoint* pa = sk.getPoint(a.id);
+        const SketchPoint* pb = sk.getPoint(b.id);
+        if (pa && pb)
+            out = {ConstraintType::Distance, a.id, b.id,
+                   static_cast<double>(glm::distance(pa->pos, pb->pos)), true};
+        return out;
+    }
+    if (a.kind == DimEntityKind::Point && b.kind == DimEntityKind::Line) {
+        const SketchPoint* p = sk.getPoint(a.id);
+        glm::vec2 s, e;
+        if (p && lineEnds(b.id, s, e)) {
+            double d = perpDist(p->pos, s, e);
+            if (d >= 0.0) out = {ConstraintType::DistancePointLine, a.id, b.id, d, true};
+        }
+        return out;
+    }
+    if (a.kind == DimEntityKind::Line && b.kind == DimEntityKind::Line) {
+        glm::vec2 as, ae, bs, be;
+        if (!lineEnds(a.id, as, ae) || !lineEnds(b.id, bs, be)) return out;
+        glm::vec2 da = ae - as, db = be - bs;
+        if (glm::length(da) < 1e-10f || glm::length(db) < 1e-10f) return out;
+        // Signed angle of B relative to A, wrapped to [-π, π] — same
+        // convention as the solver's Angle error term.
+        double ang = std::atan2(db.y, db.x) - std::atan2(da.y, da.x);
+        while (ang >  M_PI) ang -= 2.0 * M_PI;
+        while (ang < -M_PI) ang += 2.0 * M_PI;
+        // Parallel (or anti-parallel) within 1°: distance dim. The point is
+        // the SECOND line's start, measured to the FIRST line, so the first
+        // pick stays the reference for both branches.
+        const double kParallelTol = 1.0 * M_PI / 180.0;
+        double folded = std::min(std::abs(ang), M_PI - std::abs(ang));
+        if (folded <= kParallelTol) {
+            const SketchLine* lb = lineById(b.id);
+            double d = perpDist(bs, as, ae);
+            if (lb && d >= 0.0)
+                out = {ConstraintType::DistancePointLine, lb->startPointId, a.id, d, true};
+        } else {
+            out = {ConstraintType::Angle, a.id, b.id, ang, true};
+        }
+        return out;
+    }
+    return out; // circle/arc pairs and circle+point: out of scope
+}
+```
+
+Needs `#include <cmath>` and `M_PI` (already used elsewhere in the file's includes — verify).
+
+Accessor bodies (header, inline): `getDimPhase`, `getDimPickA`, `getPendingDimension`, `getDimLabelPos`, `dimReadyToCommit` return the corresponding members; `dimHitTest(pos)` forwards to `hitTestDimEntity(pos)`.
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `cmake --build build -j 8 --target test_sketch_dimension && ./build/tests/test_sketch_dimension`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Full build (nothing else broke the mode enum switches)**
+
+Run: `cmake --build build -j 8 2>&1 | tail -20`
+Expected: clean build. If a switch over `SketchToolMode` warns/errs on the new enumerator, add a no-op `case SketchToolMode::Dimension:` there.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/modeling/SketchTool.h src/modeling/SketchTool.cpp tests/test_sketch_dimension.cpp
+git commit -m "sketch: Dimension tool state machine + pick resolution (line-line ref = first pick)"
+```
+
+---
+
+### Task 4: App integration — `d` key, click routing, commit path
+
+**Files:**
+- Modify: `src/app/Application.h` (declare `applyPendingDimension()`)
+- Modify: `src/app/Application.cpp` (key binding near the Ctrl+D handler at ~line 2340; `applyPendingDimension` near `applySketchConstraint` at ~line 4384)
+- Modify: `src/app/Application_Viewport.cpp` (click routing branch at ~line 5805)
+
+**Interfaces:**
+- Consumes: `SketchTool` Dimension API (Task 3), `recordSketchMutation(fn)`, `m_activeSketch`, `m_dimEditingId` / `m_dimEditingBuf` / `m_dimEditingFocus` + `##DimEdit` popup (existing, `Application_Viewport.cpp` ~2344-2560).
+- Produces: `void Application::applyPendingDimension();` — commits the tool's pending dimension as one undoable constraint add (with dedup-replace), then opens the existing value-edit popup on it.
+
+- [ ] **Step 1: Key binding**
+
+`src/app/Application.cpp`, immediately BEFORE the Ctrl+D duplicate block (~line 2340):
+
+```cpp
+    // Plain D — Dimension tool in sketch mode (Onshape-style). Ctrl+D stays
+    // Duplicate (handled below); text-input focus swallows the key.
+    if (m_inSketchMode && m_sketchTool && !io.KeyCtrl && !io.WantTextInput &&
+        ImGui::IsKeyPressed(ImGuiKey_D, false)) {
+        m_sketchTool->setMode(SketchToolMode::Dimension);
+    }
+```
+
+- [ ] **Step 2: Commit path**
+
+`src/app/Application.h` — next to `applySketchConstraint` (line 338):
+
+```cpp
+    // Commit the Dimension tool's resolved pending dimension: one undoable
+    // constraint add (or value+label update when the same pair is already
+    // dimensioned), then open the ##DimEdit popup on it for value entry.
+    void applyPendingDimension();
+```
+
+`src/app/Application.cpp` — after `applySketchConstraint`:
+
+```cpp
+void Application::applyPendingDimension() {
+    if (!m_inSketchMode || !m_activeSketch || !m_sketchTool) return;
+    const PendingDimension& pd = m_sketchTool->getPendingDimension();
+    if (!pd.valid || !m_sketchTool->dimReadyToCommit()) return;
+
+    // Label offset = placed position minus the auto anchor the renderer uses.
+    // The renderer resolves anchor per type; store the raw placed position
+    // relative to the dimension's geometric anchor (computed the same way the
+    // label pass does — see dimensionAutoAnchor in Application_Viewport.cpp).
+    glm::vec2 anchor = dimensionAutoAnchor(pd);           // Task 5 helper
+    glm::vec2 off = m_sketchTool->getDimLabelPos() - anchor;
+
+    int editId = -1;
+    recordSketchMutation([&] {
+        // Dedup: same type on the same (unordered) entity pair replaces the
+        // value + label instead of stacking — matches applyDimension's policy.
+        for (const auto& c : m_activeSketch->getConstraints()) {
+            if (c.type != pd.type) continue;
+            bool same = (c.entityA == pd.entityA && c.entityB == pd.entityB);
+            bool swapped = (c.type == ConstraintType::Distance &&
+                            c.entityA == pd.entityB && c.entityB == pd.entityA);
+            if (same || swapped) {
+                m_activeSketch->updateConstraintValue(c.id, pd.measured);
+                m_activeSketch->setConstraintLabelOffset(c.id, off.x, off.y);
+                editId = c.id;
+                return;
+            }
+        }
+        Constraint c{};
+        c.type = pd.type;
+        c.entityA = pd.entityA;
+        c.entityB = pd.entityB;
+        c.value = pd.measured;
+        c.labelOffX = off.x;
+        c.labelOffY = off.y;
+        editId = m_activeSketch->addConstraint(c);
+    });
+    m_sketchTool->clearDimState();
+
+    // Open the existing edit popup, prefilled with the measured value —
+    // Enter drives the geometry, Esc keeps the measured value.
+    if (editId >= 0) {
+        m_dimEditingId = editId;
+        if (pd.type == ConstraintType::Angle)
+            std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f",
+                          pd.measured * 180.0 / M_PI);
+        else if (pd.type == ConstraintType::Radius)
+            std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f",
+                          pd.measured * 2.0); // edited as diameter
+        else
+            std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f", pd.measured);
+        m_dimEditingFocus = true;
+        m_dimOpenEditRequested = true; // viewport OpenPopup s ##DimEdit next frame
+    }
+}
+```
+
+Supporting pieces this step also adds:
+- `Sketch::updateConstraintValue(int id, double v)` and `Sketch::setConstraintLabelOffset(int id, double x, double y)` — if no value-setter exists yet (check `grep -n "updateConstraintValue\|setConstraint" src/modeling/Sketch.h`), add both as trivial find-and-set members in `Sketch.cpp` (the `##DimEdit` popup already writes values somehow — reuse THAT mechanism if present instead of adding a duplicate; adapt this code to whichever setter exists).
+- `bool m_dimOpenEditRequested = false;` on `Application` (`Application.h`, near `m_dimEditingId` — find with `grep -n "m_dimEditingId" src/app/Application.h`): the popup must be opened from the viewport window's ImGui scope; the existing label-click path calls `ImGui::OpenPopup("##DimEdit")` inline there. In the viewport's dimension-label section add:
+
+```cpp
+                if (m_dimOpenEditRequested) {
+                    ImGui::OpenPopup("##DimEdit");
+                    m_dimOpenEditRequested = false;
+                }
+```
+
+- Angle popup note: the existing `##DimEdit` commit path already converts the typed degrees back for Angle and doubles/halves for Radius (read the commit handler around `Application_Viewport.cpp:2541` and confirm; it drives the existing label-click edits, so no change expected).
+
+- [ ] **Step 3: Click routing**
+
+`src/app/Application_Viewport.cpp`, in the sketch mouse-down chain (~line 5805) — add a branch BEFORE the `materializr::touchMode()` branch (dimension picking must not fall into the press-drag-release paths):
+
+```cpp
+                    } else if (m_sketchTool->getMode() == SketchToolMode::Dimension) {
+                        // Picking mutates nothing — no undo record. The commit
+                        // below records the constraint add as one SketchEditOp.
+                        m_sketchTool->onMouseDown(sketchCoord, false);
+                        if (m_sketchTool->dimReadyToCommit())
+                            applyPendingDimension();
+                    } else if (materializr::touchMode()) {
+```
+
+- [ ] **Step 4: Build + smoke test**
+
+Run: `cmake --build build -j 8 2>&1 | tail -5`
+Expected: clean. Manual smoke (needs a display; Little Snitch rule already persisted): launch the app, enter sketch mode, draw a line, press `d`, click the line, click empty space, type `25`, Enter → line resizes to 25 mm, label shows `25.00 mm`, Ctrl+Z removes the dimension. Defer the full manual matrix to Task 6 if headless.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/Application.h src/app/Application.cpp src/app/Application_Viewport.cpp src/modeling/Sketch.h src/modeling/Sketch.cpp
+git commit -m "sketch: d-key Dimension tool — routing and constraint commit path"
+```
+
+---
+
+### Task 5: Viewport rendering — hover, ghost label, leaders, offsets
+
+**Files:**
+- Modify: `src/app/Application_Viewport.cpp` (dimension-label pass at ~line 2344; sketch overlay for hover/ghost)
+- Modify: `src/app/Application.h` (declare `dimensionAutoAnchor`)
+
+**Interfaces:**
+- Consumes: `SketchTool::dimHitTest`, `getDimPhase`, `getPendingDimension`, `getCurrentPos`, `Constraint::labelOffX/Y`.
+- Produces: `glm::vec2 Application::dimensionAutoAnchor(const PendingDimension&) const` — sketch-space auto anchor per dimension type; Task 4's commit already calls it (implement here, declare in the same commit as Task 4 if building incrementally — otherwise stub it returning the label pos so Task 4 compiles, then finish here).
+
+- [ ] **Step 1: Auto-anchor helper**
+
+`Application.h` (private, near other sketch helpers):
+
+```cpp
+    // Sketch-space auto anchor of a dimension's label: line/pair midpoint,
+    // circle/arc center, or the midpoint of the point-to-line perpendicular
+    // foot segment. Label offsets are stored relative to this.
+    glm::vec2 dimensionAutoAnchor(const PendingDimension& pd) const;
+```
+
+`Application_Viewport.cpp` (near the label pass so the two stay in sync):
+
+```cpp
+glm::vec2 Application::dimensionAutoAnchor(const PendingDimension& pd) const {
+    if (!m_activeSketch || !pd.valid) return glm::vec2(0.0f);
+    const Sketch& sk = *m_activeSketch;
+    auto lineEnds = [&sk](int id, glm::vec2& s, glm::vec2& e) {
+        for (const auto& l : sk.getLines())
+            if (l.id == id) {
+                const SketchPoint* sp = sk.getPoint(l.startPointId);
+                const SketchPoint* ep = sk.getPoint(l.endPointId);
+                if (!sp || !ep) return false;
+                s = sp->pos; e = ep->pos; return true;
+            }
+        return false;
+    };
+    switch (pd.type) {
+        case ConstraintType::Distance: {
+            const SketchPoint* a = sk.getPoint(pd.entityA);
+            const SketchPoint* b = sk.getPoint(pd.entityB);
+            return (a && b) ? 0.5f * (a->pos + b->pos) : glm::vec2(0.0f);
+        }
+        case ConstraintType::Radius: {
+            for (const auto& c : sk.getCircles())
+                if (c.id == pd.entityA) {
+                    const SketchPoint* ctr = sk.getPoint(c.centerPointId);
+                    if (ctr) return ctr->pos;
+                }
+            for (const auto& a : sk.getArcs())
+                if (a.id == pd.entityA) {
+                    const SketchPoint* ctr = sk.getPoint(a.centerPointId);
+                    if (ctr) return ctr->pos;
+                }
+            return glm::vec2(0.0f);
+        }
+        case ConstraintType::DistancePointLine: {
+            const SketchPoint* p = sk.getPoint(pd.entityA);
+            glm::vec2 s, e;
+            if (p && lineEnds(pd.entityB, s, e)) {
+                glm::vec2 d = e - s;
+                float len2 = glm::dot(d, d);
+                if (len2 > 1e-12f) {
+                    float t = glm::dot(p->pos - s, d) / len2; // foot on infinite line
+                    glm::vec2 foot = s + d * t;
+                    return 0.5f * (p->pos + foot);
+                }
+            }
+            return p ? p->pos : glm::vec2(0.0f);
+        }
+        case ConstraintType::Angle: {
+            glm::vec2 as, ae, bs, be;
+            if (lineEnds(pd.entityA, as, ae) && lineEnds(pd.entityB, bs, be))
+                return 0.25f * (as + ae + bs + be);
+            return glm::vec2(0.0f);
+        }
+        default: return glm::vec2(0.0f);
+    }
+}
+```
+
+- [ ] **Step 2: Stored offsets + leader lines in the label pass**
+
+In the label pass (~2395 onward), each type currently computes `mid + perp`-style auto positions. Change the pattern per type to:
+
+```cpp
+                        glm::vec2 anchor = /* existing auto anchor for this type */;
+                        glm::vec2 autoOff = /* existing offset computation */;
+                        bool placed = (c.labelOffX != 0.0 || c.labelOffY != 0.0);
+                        glm::vec2 lpos = placed
+                            ? anchor + glm::vec2(static_cast<float>(c.labelOffX),
+                                                 static_cast<float>(c.labelOffY))
+                            : anchor + autoOff;
+                        if (placed) {
+                            // Leader: thin line from the geometry anchor to the label.
+                            ImVec2 sa, sb;
+                            if (toImg(dim2world(anchor), sa) && toImg(dim2world(lpos), sb))
+                                dl->AddLine(sa, sb, IM_COL32(255, 235, 120, 90), 1.0f);
+                        }
+                        drawLabel(lpos, lbl, c);
+```
+
+Apply to the existing `Distance`, `Radius`, `Angle` branches, and add a new branch for `DistancePointLine`:
+
+```cpp
+                    } else if (c.type == ConstraintType::DistancePointLine) {
+                        PendingDimension pd;
+                        pd.type = c.type; pd.entityA = c.entityA;
+                        pd.entityB = c.entityB; pd.valid = true;
+                        glm::vec2 anchor = dimensionAutoAnchor(pd);
+                        std::snprintf(lbl, sizeof(lbl), "%.2f mm", c.value);
+                        // (same placed/leader pattern as above; autoOff = (2,2))
+```
+
+- [ ] **Step 3: Hover highlight + ghost label**
+
+In the sketch overlay section (same scope as the label pass, where `dl`, `dim2world`, `toImg` are available), when `m_sketchTool->getMode() == SketchToolMode::Dimension`:
+
+```cpp
+                // Dimension tool feedback: highlight the hovered pickable
+                // entity; after picks resolve, ghost the pending label at the
+                // cursor with a leader from its anchor.
+                DimPick hov = m_sketchTool->dimHitTest(sketchCursor);
+                // sketchCursor: current mouse in sketch coords — reuse the
+                // same unprojection the click handler feeds onMouseDown.
+                if (hov.kind == DimEntityKind::Point) {
+                    const SketchPoint* p = m_activeSketch->getPoint(hov.id);
+                    ImVec2 sp;
+                    if (p && toImg(dim2world(p->pos), sp))
+                        dl->AddCircle(sp, 7.0f, IM_COL32(255, 235, 120, 255), 0, 2.0f);
+                } else if (hov.kind == DimEntityKind::Line) {
+                    // overdraw the segment in accent color
+                    for (const auto& l : m_activeSketch->getLines())
+                        if (l.id == hov.id) {
+                            const SketchPoint* a = m_activeSketch->getPoint(l.startPointId);
+                            const SketchPoint* b = m_activeSketch->getPoint(l.endPointId);
+                            ImVec2 sa, sb;
+                            if (a && b && toImg(dim2world(a->pos), sa) &&
+                                toImg(dim2world(b->pos), sb))
+                                dl->AddLine(sa, sb, IM_COL32(255, 235, 120, 200), 3.0f);
+                        }
+                } // circles/arcs: AddCircle at center with radius in screen px
+                  // (project center and center+radius*X to get screen radius).
+
+                const PendingDimension& pend = m_sketchTool->getPendingDimension();
+                if (pend.valid &&
+                    (m_sketchTool->getDimPhase() == DimPhase::PlaceLabel ||
+                     m_sketchTool->getDimPhase() == DimPhase::PickSecondOrPlace)) {
+                    char gbuf[40];
+                    if (pend.type == ConstraintType::Angle)
+                        std::snprintf(gbuf, sizeof(gbuf), "%.1f°",
+                                      std::abs(pend.measured) * 180.0 / M_PI);
+                    else if (pend.type == ConstraintType::Radius)
+                        std::snprintf(gbuf, sizeof(gbuf), "⌀%.2f", pend.measured * 2.0);
+                    else
+                        std::snprintf(gbuf, sizeof(gbuf), "%.2f mm", pend.measured);
+                    glm::vec2 anchor = dimensionAutoAnchor(pend);
+                    ImVec2 sa, sc;
+                    if (toImg(dim2world(anchor), sa) &&
+                        toImg(dim2world(sketchCursor), sc)) {
+                        dl->AddLine(sa, sc, IM_COL32(255, 235, 120, 90), 1.0f);
+                        dl->AddText(ImVec2(sc.x + 8, sc.y - 8),
+                                    IM_COL32(255, 235, 120, 220), gbuf);
+                    }
+                }
+```
+
+Also route mouse-move: where the sketch cursor position is computed each frame for other tools, call `m_sketchTool->onMouseMove(sketchCursor)` in Dimension mode too (check it isn't already called unconditionally — `grep -n "onMouseMove" src/app/Application_Viewport.cpp`).
+
+Overlay hint text — `SketchPlugin::renderOverlay` prints the mode banner; add a Dimension-mode banner (in `src/plugins/SketchPlugin.cpp`, `renderOverlay`):
+
+```cpp
+        // (inside renderOverlay, replacing the single Text call with a mode check)
+        if (m_sketchTool->getMode() == SketchToolMode::Dimension) {
+            const char* msg = "DIMENSION - Click an entity to dimension.";
+            switch (m_sketchTool->getDimPhase()) {
+                case DimPhase::PickSecondOrPlace:
+                    msg = "DIMENSION - Click a second entity, or empty space to place."; break;
+                case DimPhase::PlaceLabel:
+                    msg = "DIMENSION - Click to place the label."; break;
+                default: break;
+            }
+            ImGui::Text("%s", msg);
+        } else {
+            ImGui::Text(/* existing sketch-mode banner */);
+        }
+```
+
+- [ ] **Step 4: Build + visual check**
+
+Run: `cmake --build build -j 8 2>&1 | tail -5`
+Expected: clean. Visual: hover highlights each entity kind; ghost label + leader track the cursor; placed labels sit where clicked and survive save/reload.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/Application.h src/app/Application_Viewport.cpp src/plugins/SketchPlugin.cpp
+git commit -m "sketch dimension tool: hover highlight, ghost label, leaders, stored label offsets"
+```
+
+---
+
+### Task 6: Toolbar + help + full verification
+
+**Files:**
+- Modify: `src/ui/Toolbar.h` (ToolAction), `src/ui/Toolbar.cpp` (desktop `skBtn` row ~line 649; touch `add()` row ~line 160)
+- Modify: `src/app/Application.cpp` (ToolAction dispatch ~line 1792)
+- Modify: `src/ui/HelpPanel.cpp` (Sketching section ~line 46)
+
+**Interfaces:**
+- Consumes: `SketchToolMode::Dimension` (enum int 12: None0…Mirror11,Dimension12), `skBtn(label, modeId)` (`Toolbar.cpp:566`), touch `add(icon, label, action, active, tip)` (`Toolbar.cpp:160`).
+- Produces: `ToolAction::SketchDimension`.
+
+- [ ] **Step 1: ToolAction + buttons + dispatch**
+
+`Toolbar.h` — in the sketch-tool group of the enum (line 17), append `SketchDimension` after `SketchSvg`.
+
+`Toolbar.cpp` desktop row (after the Trim button, line ~649-650):
+
+```cpp
+    if (skBtn("Dimension", 12))    action = ToolAction::SketchDimension;
+    tip("Dimension tool (D): click a line, circle, point pair, or two lines, "
+        "place the label, then type the value.");
+```
+
+`Toolbar.cpp` touch row (~line 160, after the Trim `add(...)`): reuse an existing measure-ish icon if `TouchIcons.h` has one (`grep -n MZ_ICON src/ui/TouchIcons.h`); otherwise skip the touch row and note it in the commit message (toolbar button still reachable in desktop layouts; touch parity tracked as follow-up).
+
+```cpp
+        add(MZ_ICON_MEASURE, "Dimension", ToolAction::SketchDimension,
+            m_activeSketchMode == 12,
+            "Dimension: tap entities, tap to place the label, type the value.");
+```
+
+Update the mode-int comment at `Toolbar.cpp:126` to mention `12=Dimension`.
+
+`Application.cpp` dispatch (after the `ToolAction::Trim` case, ~line 1792):
+
+```cpp
+        case ToolAction::SketchDimension:
+            if (m_inSketchMode) m_sketchTool->setMode(SketchToolMode::Dimension);
+            break;
+```
+
+- [ ] **Step 2: Help text**
+
+`HelpPanel.cpp` Sketching section — extend the existing string:
+
+```cpp
+    section("Sketching",
+        "Pick Sketch on XY/XZ/YZ from the Tools panel (or Sketch on Face after "
+        "selecting one), then choose a tool: Line, Rectangle, Circle, Arc, "
+        "Spline, Polygon, or Trim. Type a numeric dimension while placing to "
+        "lock the size. Press D for the Dimension tool: click a line, circle, "
+        "two points, or two lines (parallel = distance, angled = angle), "
+        "click to place the label, then type the value. Switch to Select / "
+        "Move to drag existing points and lines — double-click empties to "
+        "select the whole sketch, then use Copy / Mirror / Rotate. Click "
+        "Finish Sketch (or press Enter) to exit.");
+```
+
+- [ ] **Step 3: Full build + full test suite**
+
+Run (UNSANDBOXED): `cmake --build build -j 8 && cd build && ctest --output-on-failure -j 4`
+Expected: full suite green, including the 4 new-ish `test_sketch_dimension` groups and all pre-existing suites.
+
+- [ ] **Step 4: Manual GUI matrix**
+
+Launch the app; in a sketch:
+1. `d` → banner shows DIMENSION; `Esc` → back to Select.
+2. Line → empty click → type 25 → Enter: length 25, label where placed.
+3. Circle → click → type 40 → Enter: diameter 40 (label ⌀).
+4. Two points → distance; point + line → perpendicular distance.
+5. Two parallel lines → distance; two angled lines → angle in degrees.
+6. Construction line variant of (4): same behavior.
+7. Re-dimension the same line: value replaced, no duplicate label.
+8. Ctrl+Z after each: dimension gone. Ctrl+D still duplicates (no clash).
+9. Save, reload: labels at placed positions; open an OLD project: loads clean.
+10. Esc in value input: dimension stays at measured value.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/Toolbar.h src/ui/Toolbar.cpp src/app/Application.cpp src/ui/HelpPanel.cpp
+git commit -m "sketch dimension tool: toolbar button, D shortcut help"
+```
+
+---
+
+## Self-Review Notes (resolved during planning)
+
+- **Spec deviation, line-line reference:** spec says "first line's start point ↔ second line"; the plan (and tests) use second line's start point ↔ first line, keeping the first pick as the reference entity in both parallel and angle branches. Same geometry, more consistent; noted in Task 3's commit message.
+- **Value input reuse:** spec's "inline input at the label" is implemented by opening the existing `##DimEdit` popup (already positioned at the clicked label, already converts diameter/degrees). One input path, not two.
+- **Orphan cleanup:** verified generic in `Sketch::pruneOrphanPoints()` — no per-type change needed (Task 1 Step 5 double-checks).
+- **Angle spec "clamped to (0°,180°)":** existing Angle is signed [-π,π] and `##DimEdit` already handles it; the ghost label shows `abs()`. No new clamping introduced — behavior matches existing Angle constraint edits.

--- a/docs/superpowers/specs/2026-07-19-sketch-dimension-tool-design.md
+++ b/docs/superpowers/specs/2026-07-19-sketch-dimension-tool-design.md
@@ -1,0 +1,213 @@
+# Sketch Dimension Tool — Design Spec
+
+**Date:** 2026-07-19
+**Status:** Approved (design), pending implementation
+**Branch:** `feature/sketch-dimension-tool`
+
+## Summary
+
+An Onshape-style dimension tool for sketch mode, bound to the `d` key. The user
+clicks sketch entities (points, lines, circles, arcs — regular or construction),
+places a dimension label with a second click, and types a value. The tool
+creates driving constraints: distances, lengths, diameters, and angles.
+
+This replaces the current workflow where dimensioning existing geometry requires
+the right-click "Add Constraint" menu, which offers no value input at creation
+time and no label placement.
+
+## Goals
+
+- `d` activates a Dimension tool inside sketch mode; `Esc` returns to Select.
+- Dimension existing geometry: line length, circle/arc diameter, point-to-point
+  distance, point-to-line distance, parallel line-to-line distance, angle
+  between non-parallel lines.
+- Construction geometry dimensions identically to regular geometry.
+- Onshape-style label placement: the label follows the cursor after entity
+  selection; a click fixes its position (persisted); an inline value input
+  opens prefilled with the measured value.
+- Tool stays active after each dimension so several can be placed in a row.
+
+## Non-Goals
+
+- Driven/reference dimensions (read-only dims on over-constrained geometry).
+- Dimensions on splines, polygons-as-units, or text glyph geometry.
+- Circle-to-line or circle-to-circle distance dimensions.
+- 3D (non-sketch) dimensioning — the existing `MeasureTool` covers measuring.
+
+## UX Flow
+
+### Activation
+
+- `d` key in sketch mode → `SketchToolMode::Dimension`. Guards: not when a text
+  field has focus (`io.WantTextInput`), not with Ctrl held (Ctrl+D = duplicate).
+- A toolbar button in the sketch toolbar activates the same mode (touch users
+  have no keyboard).
+- `Esc` while in Dimension mode with no pending picks → back to Select mode.
+  `Esc` with pending picks → clear picks, stay in Dimension mode.
+- Overlay hint text (same pattern as other sketch tools) shows current state:
+  "DIMENSION — click an entity" / "click second entity or place label" /
+  "click to place label".
+
+### Entity picking
+
+Hover highlights the entity under the cursor (reuses Select-mode hit-testing
+tolerances). Click sequence:
+
+| First pick | Then | Result |
+|---|---|---|
+| circle or arc | — | diameter dim → placing state |
+| line | click empty space / place label | line length (Distance between endpoints) |
+| line | click second line, parallel within 1° | `DistancePointLine` (first line's start point ↔ second line) |
+| line | click second line, non-parallel | `Angle` |
+| line | click point | `DistancePointLine` (point ↔ line) |
+| point | click point | `Distance` |
+| point | click line | `DistancePointLine` (point ↔ line) |
+| point | click empty space | no-op (a lone point has no dimension); pick stays pending |
+
+Clicking a spline, text geometry (`fromText`), or empty space on first pick does
+nothing.
+
+### Label placement and value input
+
+1. Once the entity set is complete, a ghost label showing the measured value
+   follows the cursor, with a thin leader line from the geometry anchor.
+2. Click fixes the label: the offset from the auto anchor (sketch-space vec2) is
+   stored on the constraint and persisted.
+3. An inline input opens at the label, prefilled with the measured value
+   (diameter for circles/arcs, degrees for angles, mm otherwise), text
+   pre-selected.
+4. `Enter` → constraint takes the typed value, solver runs.
+   `Esc` (or clicking away) → constraint keeps the measured value.
+5. Either way the constraint is created as one undoable mutation, and the tool
+   returns to its idle picking state.
+
+Duplicate policy: creating a dimension on a pair that already carries the same
+constraint type replaces the old value instead of stacking a duplicate
+(matches the existing `applyDimension` dedup behavior).
+
+## Architecture
+
+### New constraint type
+
+`ConstraintType::DistancePointLine` — **appended** to the enum (append-only
+policy for serialization stability).
+
+- `entityA` = point id, `entityB` = line id.
+- `value` = perpendicular distance from the point to the **infinite** line.
+- Residual in `SketchSolver.cpp`:
+  `|cross2(dir, p − a)| / |dir| − value`, where `a` is the line's start point
+  and `dir` its direction. Degenerate (zero-length) lines return residual 0,
+  same guard style as existing constraints.
+- Line-to-line distance is expressed as this constraint using the first line's
+  start point, so no separate line-line type exists.
+
+### Constraint label offset
+
+`Constraint` gains:
+
+```cpp
+double labelOffX = 0.0;  // sketch-space offset of the dimension label
+double labelOffY = 0.0;  // from its auto-computed anchor; 0,0 = auto placement
+```
+
+`(0,0)` means "legacy / auto placement" — existing constraints and old files
+keep today's automatic label positioning.
+
+### Tool state machine (`SketchTool`)
+
+`SketchToolMode::Dimension` added to the mode enum. New state on `SketchTool`:
+
+- `m_dimPickA` / `m_dimPickB` — picked entity refs (kind + id).
+- `m_dimPhase` — `PickFirst | PickSecondOrPlace | PlaceLabel`.
+- Pair-resolution helper returning the constraint type + entity ids for a
+  completed pick set (unit-testable pure logic).
+
+`SketchTool` owns picking and phase transitions. It does **not** create the
+constraint itself — it exposes the resolved pending dimension; the application
+layer commits it through the undo-recording path (same split as the existing
+`applyDimension` / `recordMutation` pattern in `SketchPlugin`).
+
+### Input routing and rendering (`Application_Viewport.cpp`)
+
+- Routes sketch-space clicks/moves to the tool when Dimension mode is active
+  (same plumbing as other sketch tool modes).
+- Renders: hover highlight, ghost label + leader line during placement, inline
+  value input (ImGui window at the label position, `EnterReturnsTrue`).
+- Existing dimension-label pass extends to:
+  - use `labelOff` when non-zero, falling back to today's auto offsets;
+  - draw a thin leader line from the geometry anchor to the label when the
+    label carries a stored offset;
+  - render `DistancePointLine` labels (anchor: midpoint of the perpendicular
+    foot segment).
+- The existing click-to-edit popup (`##DimEdit`) works unchanged for the new
+  type — it edits `c.value` generically.
+
+### Key binding (`Application.cpp`)
+
+In the sketch-mode key handling block: plain `d` (no Ctrl, `!io.WantTextInput`)
+sets the sketch tool to Dimension mode. Sits beside the existing Ctrl+D
+duplicate handler, which keeps priority via its Ctrl guard.
+
+### Persistence (`ProjectIO.cpp`)
+
+K-line gains two trailing fields:
+
+```
+K id type entityA entityB value valueY labelOffX labelOffY
+```
+
+- Writer always emits the two new fields.
+- Reader reads them with a guarded extraction; missing fields (old files) →
+  `0 0` (auto placement). Old readers ignore trailing tokens on the line, so
+  files written by the new build still load in old builds (minus offsets).
+- `DistancePointLine` round-trips as its enum int, consistent with the
+  append-only policy already documented in the writer.
+
+### Discoverability
+
+- `Toolbar.cpp`: Dimension button in the sketch tool group.
+- `HelpPanel.cpp`: shortcut entry for `d`.
+
+## Touched Files
+
+| File | Change |
+|---|---|
+| `src/modeling/SketchConstraints.h` | enum append, label offset fields |
+| `src/modeling/SketchSolver.cpp` | `DistancePointLine` residual + satisfied check |
+| `src/modeling/SketchTool.h/.cpp` | Dimension mode state machine |
+| `src/app/Application.cpp` | `d` key binding |
+| `src/app/Application_Viewport.cpp` | picking routing, ghost label, inline input, label rendering |
+| `src/io/ProjectIO.cpp` | K-line extension, guarded read |
+| `src/ui/Toolbar.cpp` | sketch toolbar button |
+| `src/ui/HelpPanel.cpp` | shortcut documentation |
+| `tests/` | new headless tests (below) |
+
+## Error Handling
+
+- Zero-length line in `DistancePointLine` residual → 0 (no NaN into solver).
+- Deleting a referenced point/line: existing constraint-orphan cleanup path
+  must also cover the new type (entityB is a line id — verify the cleanup
+  checks line ids for it).
+- Value input: parsed with the existing `parseFinite` guard; non-positive
+  distance/diameter rejected (input stays open); angle clamped to (0°, 180°).
+- Over-constraint: no special casing — solver's existing
+  `FullyConstrained/OverConstrained` status badge reports it, matching current
+  behavior for the right-click menu.
+
+## Testing
+
+Headless (ctest — run **unsandboxed**; sandboxed runs false-fail on /tmp writes):
+
+1. **Solver:** `DistancePointLine` — free point converges to the target
+   distance from a fixed line; degenerate line doesn't NaN.
+2. **Pair resolution:** unit test the pure pick-resolution helper — all rows of
+   the picking table above map to the right constraint type/entities,
+   parallel-vs-angle threshold behaves at the 1° boundary.
+3. **Persistence:** round-trip a sketch containing a `DistancePointLine`
+   constraint with non-zero label offsets; load a legacy K-line (6 fields) and
+   confirm offsets default to 0.
+4. **Dedup:** dimensioning the same pair twice replaces the value, doesn't
+   stack.
+
+Manual (GUI): place each dimension kind, drag-place labels, type values, undo/
+redo, save/reload, construction-line variant.

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -5112,6 +5112,17 @@ void Application::applyPendingDimension() {
             c.value = pd.measured;
             c.labelOffX = off.x;
             c.labelOffY = off.y;
+            // Dimensions are REFERENCE by default: placing one measures the
+            // geometry without moving it. The solver skips it and it costs no
+            // degree of freedom, so annotating a sketch can never drag it out
+            // of shape or flip it to Over-constrained. The label's edit popup
+            // has a "Driving" checkbox to promote it when the user actually
+            // wants the number to control the geometry.
+            //
+            // Only here — Constraint::isDriving defaults to true, so the
+            // right-click Add Constraint menu and every geometric constraint
+            // are unaffected.
+            c.isDriving = false;
             editId = m_activeSketch->addConstraint(c);
         }
         if (m_sketchSolver) {
@@ -5203,6 +5214,10 @@ void Application::recordSketchMutation(const std::function<void()>& mutator) {
             mix(vb);
             std::memcpy(&vb, &c.labelOffY, sizeof(vb));
             mix(vb);
+            // Driving/reference too — promoting a dimension changes no
+            // number, so without this the toggle hashes identically and
+            // recordSketchMutation skips the history push entirely.
+            mix(static_cast<size_t>(c.isDriving ? 1 : 0));
         }
         return h;
     };

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -4908,7 +4908,10 @@ void Application::applySketchConstraint(ConstraintType type) {
 
 void Application::applyPendingDimension() {
     if (!m_inSketchMode || !m_activeSketch || !m_sketchTool) return;
-    const PendingDimension& pd = m_sketchTool->getPendingDimension();
+    // Value copy: clearDimState() below resets the tool's live m_dimPending
+    // to defaults, so a reference here would read back type=Distance,
+    // measured=0.0 by the time the prefill code runs.
+    const PendingDimension pd = m_sketchTool->getPendingDimension();
     if (!pd.valid || !m_sketchTool->dimReadyToCommit()) return;
 
     // Label offset = placed position minus the auto anchor the renderer uses.
@@ -4968,8 +4971,13 @@ void Application::applyPendingDimension() {
             std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f", pd.measured);
         m_dimEditingFocus = true;
         m_dimOpenEditRequested = true; // viewport calls OpenPopup("##DimEdit") next frame
+        // No m_meshesDirty here: pd.measured is always the geometry's CURRENT
+        // value (resolveDimension reads it off the live picks), so this commit
+        // never moves anything for the solver to re-tessellate — same as
+        // applySketchConstraint's Distance/Angle path just above, which
+        // doesn't set it either. The ##DimEdit popup's own commit handler
+        // sets m_meshesDirty when a typed value actually changes geometry.
         markDirty();
-        m_meshesDirty = true;
     }
 }
 

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -2330,6 +2330,12 @@ void Application::handleShortcuts() {
     if (io.KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_O)) {
         loadProject();
     }
+    // Plain D — Dimension tool in sketch mode (Onshape-style). Ctrl+D stays
+    // Duplicate (handled below); text-input focus swallows the key.
+    if (m_inSketchMode && m_sketchTool && !io.KeyCtrl && !io.WantTextInput &&
+        ImGui::IsKeyPressed(ImGuiKey_D, false)) {
+        m_sketchTool->setMode(SketchToolMode::Dimension);
+    }
     // Ctrl+D — Duplicate in place. Branches on selection type:
     //   Body   → CopyOp (full history support, undoable via Ctrl+Z)
     //   Axis   → Document::addAxis with the source's origin/direction
@@ -4898,6 +4904,73 @@ void Application::applySketchConstraint(ConstraintType type) {
     }
     }); // end recordSketchMutation
     if (added > 0) markDirty();
+}
+
+void Application::applyPendingDimension() {
+    if (!m_inSketchMode || !m_activeSketch || !m_sketchTool) return;
+    const PendingDimension& pd = m_sketchTool->getPendingDimension();
+    if (!pd.valid || !m_sketchTool->dimReadyToCommit()) return;
+
+    // Label offset = placed position minus the auto anchor the renderer uses.
+    // The renderer resolves anchor per type; store the raw placed position
+    // relative to the dimension's geometric anchor (computed the same way the
+    // label pass does — see dimensionAutoAnchor in Application_Viewport.cpp).
+    glm::vec2 anchor = dimensionAutoAnchor(pd);
+    glm::vec2 off = m_sketchTool->getDimLabelPos() - anchor;
+
+    int editId = -1;
+    recordSketchMutation([&] {
+        // Dedup: same type on the same (unordered) entity pair replaces the
+        // value + label instead of stacking — matches applyDimension's policy.
+        bool replaced = false;
+        for (auto& c : m_activeSketch->getMutableConstraints()) {
+            if (c.type != pd.type) continue;
+            bool same = (c.entityA == pd.entityA && c.entityB == pd.entityB);
+            bool swapped = (c.type == ConstraintType::Distance &&
+                            c.entityA == pd.entityB && c.entityB == pd.entityA);
+            if (same || swapped) {
+                c.value = pd.measured;
+                c.labelOffX = off.x;
+                c.labelOffY = off.y;
+                editId = c.id;
+                replaced = true;
+                break;
+            }
+        }
+        if (!replaced) {
+            Constraint c{};
+            c.type = pd.type;
+            c.entityA = pd.entityA;
+            c.entityB = pd.entityB;
+            c.value = pd.measured;
+            c.labelOffX = off.x;
+            c.labelOffY = off.y;
+            editId = m_activeSketch->addConstraint(c);
+        }
+        if (m_sketchSolver) {
+            m_sketchSolver->setSketch(m_activeSketch.get());
+            m_sketchSolver->solve(*m_activeSketch);
+        }
+    });
+    m_sketchTool->clearDimState();
+
+    // Open the existing edit popup, prefilled with the measured value —
+    // Enter drives the geometry, Esc keeps the measured value.
+    if (editId >= 0) {
+        m_dimEditingId = editId;
+        if (pd.type == ConstraintType::Angle)
+            std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f",
+                          pd.measured * 180.0 / M_PI);
+        else if (pd.type == ConstraintType::Radius)
+            std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f",
+                          pd.measured * 2.0); // edited as diameter
+        else
+            std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f", pd.measured);
+        m_dimEditingFocus = true;
+        m_dimOpenEditRequested = true; // viewport calls OpenPopup("##DimEdit") next frame
+        markDirty();
+        m_meshesDirty = true;
+    }
 }
 
 void Application::recordSketchMutation(const std::function<void()>& mutator) {

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -2556,7 +2556,21 @@ void Application::handleShortcuts() {
             // Select mode), so a SECOND Escape lands here again with the
             // mode now Select, isPlacing() still false, and exits the sketch
             // as usual.
-            if (m_sketchTool && m_sketchTool->getMode() == SketchToolMode::Dimension) {
+            //
+            // The ##DimEdit value-entry popup (Application_Viewport.cpp)
+            // ALSO wants Escape (to dismiss itself and keep the measured
+            // value, staying in Dimension/idle-picking, per spec). It runs
+            // during renderViewport(), which happens before this shortcut
+            // handler each frame, and it clears m_dimEditingId as part of
+            // closing — so by the time we get here a naive check can no
+            // longer tell the popup was even open. m_dimPopupConsumedEsc is
+            // set by that render pass on any Escape seen while the popup was
+            // up; consume it here and do NOTHING else, so this press closes
+            // ONLY the popup. The mode-level step above happens on the NEXT
+            // Escape, once the popup is actually gone.
+            if (m_dimPopupConsumedEsc) {
+                m_dimPopupConsumedEsc = false;
+            } else if (m_sketchTool && m_sketchTool->getMode() == SketchToolMode::Dimension) {
                 m_sketchTool->onCancel();
             } else if (m_sketchTool && m_sketchTool->isPlacing()) {
                 m_sketchTool->onCancel();
@@ -4054,6 +4068,7 @@ void Application::enterSketchMode() {
     // constraint id from a different sketch.
     m_dimOpenEditRequested = false;
     m_dimEditingId = -1;
+    m_dimPopupConsumedEsc = false;
     alignCameraToActiveSketch();
 }
 
@@ -4082,6 +4097,7 @@ void Application::enterSketchOnPlane(const gp_Pln& plane) {
     // constraint id from a different sketch.
     m_dimOpenEditRequested = false;
     m_dimEditingId = -1;
+    m_dimPopupConsumedEsc = false;
     alignCameraToActiveSketch();
 }
 
@@ -4767,6 +4783,7 @@ void Application::enterSketchOnFace(const TopoDS_Face& face, int sourceBodyId) {
     // constraint id from a different sketch.
     m_dimOpenEditRequested = false;
     m_dimEditingId = -1;
+    m_dimPopupConsumedEsc = false;
     alignCameraToActiveSketch();
 }
 
@@ -5011,7 +5028,20 @@ void Application::applyPendingDimension() {
                                     pd.entityA == cLine->endPointId);
             bool cPointOnPdLine = (c.entityA == pdLine->startPointId ||
                                     c.entityA == pdLine->endPointId);
-            return pdPointOnCLine && cPointOnPdLine;
+            if (!(pdPointOnCLine && cPointOnPdLine)) return false;
+            // Endpoint cross-membership alone isn't enough: a triangle
+            // altitude dimensioned from each of two non-parallel sides in
+            // turn (P-on-L2 then P-on-L1, sharing no special relationship
+            // beyond "each point happens to be an endpoint of the other
+            // line") satisfies the membership check above but is NOT the
+            // same physical gap — treating it as a match would silently
+            // overwrite the first dimension's constraint with the second
+            // pick's entity ids while keeping the first's stale value.
+            // Mirrored derivation is only actually the same measurement
+            // when the two lines are parallel (see resolveDimension's
+            // line-line branch, which is the only place that produces this
+            // point/line pairing shape in the first place).
+            return SketchTool::linesParallelWithinDimTol(*m_activeSketch, cLine->id, pdLine->id);
         };
         for (auto& c : m_activeSketch->getMutableConstraints()) {
             if (c.type != pd.type) continue;
@@ -5373,6 +5403,7 @@ void Application::editSketch(int sketchId) {
     // constraint id from a different sketch.
     m_dimOpenEditRequested = false;
     m_dimEditingId = -1;
+    m_dimPopupConsumedEsc = false;
     m_selection->clear();
     alignCameraToActiveSketch();
 }
@@ -5656,6 +5687,7 @@ void Application::exitSketchMode() {
     // now-dangling constraint id) on the next sketch session.
     m_dimOpenEditRequested = false;
     m_dimEditingId = -1;
+    m_dimPopupConsumedEsc = false;
 
     // Persist the sketch into the document if it has any geometry. New sketches get added;
     // edits to existing sketches are already reflected via the shared_ptr.

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -4834,12 +4834,30 @@ void Application::applySketchConstraint(ConstraintType type) {
             break;
         }
         case ConstraintType::Parallel:
-        case ConstraintType::Perpendicular:
-        case ConstraintType::Equal: {
+        case ConstraintType::Perpendicular: {
             // Each subsequent line gets bound to the first.
             std::vector<int> v(selLns.begin(), selLns.end());
             for (size_t i = 1; i < v.size(); ++i) {
                 pushConstraint(type, v[0], v[i]);
+                ++added;
+            }
+            break;
+        }
+        case ConstraintType::Equal: {
+            // Equal binds LINES (equal length) or CIRCLES/ARCS (equal radius),
+            // whichever the selection holds — each subsequent entity bound to
+            // the first of its kind. A mixed selection constrains lines to
+            // lines and curves to curves independently.
+            std::vector<int> lns(selLns.begin(), selLns.end());
+            for (size_t i = 1; i < lns.size(); ++i) {
+                pushConstraint(ConstraintType::Equal, lns[0], lns[i]);
+                ++added;
+            }
+            std::vector<int> curves;
+            for (int id : m_sketchTool->getSelectedCircles()) curves.push_back(id);
+            for (int id : m_sketchTool->getSelectedArcs())    curves.push_back(id);
+            for (size_t i = 1; i < curves.size(); ++i) {
+                pushConstraint(ConstraintType::Equal, curves[0], curves[i]);
                 ++added;
             }
             break;

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -5755,8 +5755,14 @@ void Application::renderSketchRecoveryPrompt() {
     // strands the dialog in the top-left corner for good.
     ImVec2 c = ImGui::GetMainViewport()->GetCenter();
     ImGui::SetNextWindowPos(c, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    // NoSavedSettings: this window's geometry is meaningless across launches
+    // (it's re-centred every frame above), so never let a degenerate Pos/Size
+    // — e.g. from some future popup-stack collision like the update-popup one
+    // this class of bug already caused once — get written to imgui.ini and
+    // self-perpetuate as the window's starting size on the next launch.
     if (ImGui::BeginPopupModal("Recover Sketch?", nullptr,
-                               ImGuiWindowFlags_AlwaysAutoResize)) {
+                               ImGuiWindowFlags_AlwaysAutoResize |
+                               ImGuiWindowFlags_NoSavedSettings)) {
         ImGui::TextUnformatted(
             "An unfinished sketch from your last session was found.");
         ImGui::TextDisabled(
@@ -5878,8 +5884,10 @@ void Application::renderProjectRecoveryPrompt() {
     // Pinned centred every frame — see the Android note on the sketch prompt.
     ImVec2 c = ImGui::GetMainViewport()->GetCenter();
     ImGui::SetNextWindowPos(c, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    // NoSavedSettings — see the identical note on renderSketchRecoveryPrompt.
     if (ImGui::BeginPopupModal("Recover Project?", nullptr,
-                               ImGuiWindowFlags_AlwaysAutoResize)) {
+                               ImGuiWindowFlags_AlwaysAutoResize |
+                               ImGuiWindowFlags_NoSavedSettings)) {
         materializr::ProjectRecoveryMeta meta;
         materializr::readProjectRecoveryMeta(meta);
         ImGui::TextUnformatted(

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -5050,13 +5050,17 @@ void Application::applyPendingDimension() {
                                  c.entityA == pd.entityB && c.entityB == pd.entityA);
             bool angleSwapped = (c.type == ConstraintType::Angle &&
                                   c.entityA == pd.entityB && c.entityB == pd.entityA);
+            // CircleGap is symmetric in its two circles — a reversed re-pick
+            // of the same pair is the same dimension.
+            bool gapSwapped = (c.type == ConstraintType::CircleGap &&
+                                c.entityA == pd.entityB && c.entityB == pd.entityA);
             bool mirroredDPL = !same && !distSwapped && !angleSwapped && isMirroredDPL(c);
-            if (same || distSwapped || angleSwapped || mirroredDPL) {
+            if (same || distSwapped || angleSwapped || gapSwapped || mirroredDPL) {
                 // Reversed-order matches (Angle swap, mirrored
                 // DistancePointLine) adopt the NEW pick's entity order/ids
                 // so the constraint stays consistent with how it was just
                 // re-picked.
-                if (distSwapped || angleSwapped || mirroredDPL) {
+                if (distSwapped || angleSwapped || gapSwapped || mirroredDPL) {
                     c.entityA = pd.entityA;
                     c.entityB = pd.entityB;
                 }

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -2244,6 +2244,14 @@ void Application::handleShortcuts() {
                     // the now-reverted sketch instead of staying at its last shape.
                     if (m_activeSketchId >= 0) cascadeFromSketchEdit(m_activeSketchId);
                 }
+                // The undo can remove/renumber the very entities the
+                // Dimension tool has picked or is mid-pick on — stale ids
+                // referencing geometry that may no longer exist. Drop them
+                // rather than let the next click resolve against ghosts.
+                if (m_inSketchMode && m_sketchTool &&
+                    m_sketchTool->getMode() == SketchToolMode::Dimension) {
+                    m_sketchTool->clearDimState();
+                }
                 m_meshesDirty = true;
             }
         }
@@ -2265,6 +2273,11 @@ void Application::handleShortcuts() {
                 if (int sid = sketchIdEditedBy(redone);
                     sid >= 0 && !(m_inSketchMode && sid == m_activeSketchId))
                     cascadeFromSketchEdit(sid);
+                // Same stale-pick hazard as the undo path above.
+                if (m_inSketchMode && m_sketchTool &&
+                    m_sketchTool->getMode() == SketchToolMode::Dimension) {
+                    m_sketchTool->clearDimState();
+                }
                 m_meshesDirty = true;
             }
         }
@@ -2533,7 +2546,19 @@ void Application::handleShortcuts() {
             //   2nd press (or 1st press when nothing is in progress) →
             //      exit sketch mode entirely (same as Finish Sketch but
             //      without an explicit click).
-            if (m_sketchTool && m_sketchTool->isPlacing()) {
+            // Dimension mode is picking entities, not "placing" a shape —
+            // isPlacing() never goes true for it, so without this branch
+            // Escape here always fell straight through to exitSketchMode()
+            // and SketchTool::onCancel's Dimension branch (clear picks /
+            // fall back to Select) was unreachable from the keyboard. Route
+            // Dimension explicitly first; onCancel() implements both halves
+            // itself (mid-pick -> clear picks, stay in Dimension; idle ->
+            // Select mode), so a SECOND Escape lands here again with the
+            // mode now Select, isPlacing() still false, and exits the sketch
+            // as usual.
+            if (m_sketchTool && m_sketchTool->getMode() == SketchToolMode::Dimension) {
+                m_sketchTool->onCancel();
+            } else if (m_sketchTool && m_sketchTool->isPlacing()) {
                 m_sketchTool->onCancel();
             } else {
                 exitSketchMode();
@@ -4023,6 +4048,12 @@ void Application::enterSketchMode() {
     m_sketchEntryHistoryStep = m_history ? m_history->currentStep() : -1;
     if (m_history) m_history->setUndoFloor(m_sketchEntryHistoryStep);  // no undo past sketch entry
     m_toolbar->setSketchMode(true);
+    // Fresh sketch session: drop any stale Dimension edit-popup state left
+    // over from a previous session (e.g. Esc/undo left m_dimEditingId set
+    // without the popup ever closing) so it can't reopen against a
+    // constraint id from a different sketch.
+    m_dimOpenEditRequested = false;
+    m_dimEditingId = -1;
     alignCameraToActiveSketch();
 }
 
@@ -4045,6 +4076,12 @@ void Application::enterSketchOnPlane(const gp_Pln& plane) {
     m_sketchEntryHistoryStep = m_history ? m_history->currentStep() : -1;
     if (m_history) m_history->setUndoFloor(m_sketchEntryHistoryStep);  // no undo past sketch entry
     m_toolbar->setSketchMode(true);
+    // Fresh sketch session: drop any stale Dimension edit-popup state left
+    // over from a previous session (e.g. Esc/undo left m_dimEditingId set
+    // without the popup ever closing) so it can't reopen against a
+    // constraint id from a different sketch.
+    m_dimOpenEditRequested = false;
+    m_dimEditingId = -1;
     alignCameraToActiveSketch();
 }
 
@@ -4724,6 +4761,12 @@ void Application::enterSketchOnFace(const TopoDS_Face& face, int sourceBodyId) {
     m_sketchEntryHistoryStep = m_history ? m_history->currentStep() : -1;
     if (m_history) m_history->setUndoFloor(m_sketchEntryHistoryStep);  // no undo past sketch entry
     m_toolbar->setSketchMode(true);
+    // Fresh sketch session: drop any stale Dimension edit-popup state left
+    // over from a previous session (e.g. Esc/undo left m_dimEditingId set
+    // without the popup ever closing) so it can't reopen against a
+    // constraint id from a different sketch.
+    m_dimOpenEditRequested = false;
+    m_dimEditingId = -1;
     alignCameraToActiveSketch();
 }
 
@@ -4925,20 +4968,86 @@ void Application::applyPendingDimension() {
     glm::vec2 off = m_sketchTool->getDimLabelPos() - anchor;
 
     int editId = -1;
+    // Popup prefill value: the new-add path prefills from the freshly
+    // measured geometry (pd.measured). A dedup MATCH instead keeps whatever
+    // value the constraint already carried (see the loop below) — so
+    // re-picking an existing dimension just to move its label doesn't
+    // clobber a value the user hand-typed earlier — EXCEPT a reversed-order
+    // Angle match, which must renegotiate the value for correctness (see
+    // the angleSwapped comment below); that path prefills from the fresh
+    // pd.measured like a new add.
+    double prefillValue = pd.measured;
     recordSketchMutation([&] {
         // Dedup: same type on the same (unordered) entity pair replaces the
-        // value + label instead of stacking — matches applyDimension's policy.
+        // label placement instead of stacking a duplicate constraint —
+        // matches applyDimension's policy. Deliberately does NOT overwrite
+        // c.value with pd.measured on a match: pd.measured is a live
+        // re-measurement of the CURRENT geometry, which can differ from a
+        // value the user already typed into the edit popup, and clobbering
+        // it here would silently discard that typed value with no undo step
+        // to recover it (bitwise-equal values skip recordSketchMutation's
+        // history push). The one exception is angleSwapped below, where
+        // keeping the old value would be actively wrong, not just imprecise.
         bool replaced = false;
+        // Mirrored DistancePointLine pair-identity: a line-line parallel
+        // pick resolves to (point = second line's start endpoint, line =
+        // first line). Picking the SAME two lines in the opposite order
+        // resolves to the mirror pair (point = first line's start endpoint,
+        // line = second line) — a different (point,line) id pair driving
+        // the geometrically same gap between the two lines. Recognise that
+        // as the same dimension so re-picking in reversed order updates the
+        // existing constraint instead of stacking a duplicate.
+        auto isMirroredDPL = [&](const Constraint& c) -> bool {
+            if (c.type != ConstraintType::DistancePointLine ||
+                pd.type != ConstraintType::DistancePointLine) return false;
+            const SketchLine* cLine = nullptr;   // line carrying c (c.entityB)
+            const SketchLine* pdLine = nullptr;  // line carrying pd (pd.entityB)
+            for (const auto& l : m_activeSketch->getLines()) {
+                if (l.id == c.entityB) cLine = &l;
+                if (l.id == pd.entityB) pdLine = &l;
+            }
+            if (!cLine || !pdLine) return false;
+            bool pdPointOnCLine = (pd.entityA == cLine->startPointId ||
+                                    pd.entityA == cLine->endPointId);
+            bool cPointOnPdLine = (c.entityA == pdLine->startPointId ||
+                                    c.entityA == pdLine->endPointId);
+            return pdPointOnCLine && cPointOnPdLine;
+        };
         for (auto& c : m_activeSketch->getMutableConstraints()) {
             if (c.type != pd.type) continue;
             bool same = (c.entityA == pd.entityA && c.entityB == pd.entityB);
-            bool swapped = (c.type == ConstraintType::Distance &&
-                            c.entityA == pd.entityB && c.entityB == pd.entityA);
-            if (same || swapped) {
-                c.value = pd.measured;
+            bool distSwapped = (c.type == ConstraintType::Distance &&
+                                 c.entityA == pd.entityB && c.entityB == pd.entityA);
+            bool angleSwapped = (c.type == ConstraintType::Angle &&
+                                  c.entityA == pd.entityB && c.entityB == pd.entityA);
+            bool mirroredDPL = !same && !distSwapped && !angleSwapped && isMirroredDPL(c);
+            if (same || distSwapped || angleSwapped || mirroredDPL) {
+                // Reversed-order matches (Angle swap, mirrored
+                // DistancePointLine) adopt the NEW pick's entity order/ids
+                // so the constraint stays consistent with how it was just
+                // re-picked.
+                if (distSwapped || angleSwapped || mirroredDPL) {
+                    c.entityA = pd.entityA;
+                    c.entityB = pd.entityB;
+                }
+                // Value: left untouched everywhere the stored number stays
+                // geometrically correct under the (possibly new) entity
+                // order — same-order matches, a swapped Distance/mirrored
+                // DPL (both are order-independent magnitudes: a distance or
+                // a perpendicular gap reads the same regardless of which
+                // point/line ended up as entityA/entityB). Angle is NOT
+                // order-independent: c.value is defined as "entityB's angle
+                // relative to entityA's", so swapping which line is which
+                // without renegotiating the number would have the solver
+                // enforce the NEGATED relative angle against the wrong
+                // reference line — a silent geometry flip, not just a label
+                // move. pd.measured was freshly computed for the NEW order,
+                // so it's the only value consistent with the swapped roles.
+                if (angleSwapped) c.value = pd.measured;
                 c.labelOffX = off.x;
                 c.labelOffY = off.y;
                 editId = c.id;
+                prefillValue = c.value;
                 replaced = true;
                 break;
             }
@@ -4960,26 +5069,32 @@ void Application::applyPendingDimension() {
     });
     m_sketchTool->clearDimState();
 
-    // Open the existing edit popup, prefilled with the measured value —
-    // Enter drives the geometry, Esc keeps the measured value.
+    // Open the existing edit popup, prefilled from prefillValue — the
+    // freshly measured geometry for a new dimension, or the KEPT existing
+    // value for a dedup match (see the comment above; a match never writes
+    // pd.measured into c.value, so the popup must prefill from what's
+    // actually stored, not from the re-measurement). Enter drives the
+    // geometry, Esc keeps the prefilled value.
     if (editId >= 0) {
         m_dimEditingId = editId;
         if (pd.type == ConstraintType::Angle)
             std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f",
-                          pd.measured * 180.0 / M_PI);
+                          prefillValue * 180.0 / M_PI);
         else if (pd.type == ConstraintType::Radius)
             std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f",
-                          pd.measured * 2.0); // edited as diameter
+                          prefillValue * 2.0); // edited as diameter
         else
-            std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f", pd.measured);
+            std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f", prefillValue);
         m_dimEditingFocus = true;
         m_dimOpenEditRequested = true; // viewport calls OpenPopup("##DimEdit") next frame
-        // No m_meshesDirty here: pd.measured is always the geometry's CURRENT
-        // value (resolveDimension reads it off the live picks), so this commit
-        // never moves anything for the solver to re-tessellate — same as
-        // applySketchConstraint's Distance/Angle path just above, which
-        // doesn't set it either. The ##DimEdit popup's own commit handler
-        // sets m_meshesDirty when a typed value actually changes geometry.
+        // No m_meshesDirty here: for a new dimension pd.measured is the
+        // geometry's CURRENT value (resolveDimension reads it off the live
+        // picks) so this commit never moves anything for the solver to
+        // re-tessellate — same as applySketchConstraint's Distance/Angle
+        // path just above, which doesn't set it either. For a dedup match
+        // the value is untouched entirely. The ##DimEdit popup's own commit
+        // handler sets m_meshesDirty when a typed value actually changes
+        // geometry.
         markDirty();
     }
 }
@@ -5028,6 +5143,13 @@ void Application::recordSketchMutation(const std::function<void()>& mutator) {
             size_t vb; std::memcpy(&vb, &c.value, sizeof(vb));
             mix(vb);
             std::memcpy(&vb, &c.valueY, sizeof(vb));
+            mix(vb);
+            // Label offsets too: a dedup-replace that only re-places a
+            // label (value bitwise-equal) must still register as a
+            // mutation, or the re-placement gets no undo step.
+            std::memcpy(&vb, &c.labelOffX, sizeof(vb));
+            mix(vb);
+            std::memcpy(&vb, &c.labelOffY, sizeof(vb));
             mix(vb);
         }
         return h;
@@ -5245,6 +5367,12 @@ void Application::editSketch(int sketchId) {
     m_sketchEntryHistoryStep = m_history ? m_history->currentStep() : -1;
     if (m_history) m_history->setUndoFloor(m_sketchEntryHistoryStep);  // no undo past sketch entry
     m_toolbar->setSketchMode(true);
+    // Fresh sketch session: drop any stale Dimension edit-popup state left
+    // over from a previous session (e.g. Esc/undo left m_dimEditingId set
+    // without the popup ever closing) so it can't reopen against a
+    // constraint id from a different sketch.
+    m_dimOpenEditRequested = false;
+    m_dimEditingId = -1;
     m_selection->clear();
     alignCameraToActiveSketch();
 }
@@ -5524,6 +5652,10 @@ void Application::exitSketchMode() {
     m_sketchTool->setMode(SketchToolMode::None);
     m_sketchTool->setSketch(nullptr);
     m_sketchTool->setSolver(nullptr);
+    // Drop any stale Dimension edit-popup state so it can't reopen (with a
+    // now-dangling constraint id) on the next sketch session.
+    m_dimOpenEditRequested = false;
+    m_dimEditingId = -1;
 
     // Persist the sketch into the document if it has any geometry. New sketches get added;
     // edits to existing sketches are already reflected via the shared_ptr.

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -1794,6 +1794,9 @@ void Application::handleToolAction(int action) {
         case ToolAction::Trim:
             if (m_inSketchMode) m_sketchTool->setMode(SketchToolMode::Trim);
             break;
+        case ToolAction::SketchDimension:
+            if (m_inSketchMode) m_sketchTool->setMode(SketchToolMode::Dimension);
+            break;
         case ToolAction::SketchText:
             if (m_inSketchMode) {
                 // First activation: default to the UI font (always bundled).

--- a/src/app/Application.h
+++ b/src/app/Application.h
@@ -676,6 +676,10 @@ private:
     // steps. Consumed (cleared) by the chain on the SAME press it gates;
     // also cleared on every sketch enter/exit reset to avoid staleness.
     bool m_dimPopupConsumedEsc = false;
+    // Same-frame signal: the ##DimEdit popup was open when this frame's left
+    // click landed, so the click belongs to the popup (dismiss/interaction) —
+    // the Dimension tool's click routing must not treat it as a fresh pick.
+    bool m_dimPopupSwallowClick = false;
 
     // Sketch grid step in mm (drives both the visual face grid and snap-to-line)
     float m_sketchGridStep = 1.0f;

--- a/src/app/Application.h
+++ b/src/app/Application.h
@@ -666,6 +666,16 @@ private:
     // next frame — OpenPopup only works when called from the window that
     // owns the popup's ID stack, which the app-level commit path isn't in.
     bool m_dimOpenEditRequested = false;
+    // Set by the ##DimEdit popup block (Application_Viewport.cpp) the frame
+    // an Escape press is seen while the popup is up — BEFORE ImGui closes
+    // it and the block clears m_dimEditingId. renderViewport() runs before
+    // handleShortcuts() each frame, so by the time the global Escape chain
+    // asks "is a dimension popup open", m_dimEditingId is already -1; this
+    // flag is how the chain learns the popup just consumed this Escape
+    // press instead of falling through to the Dimension-mode / sketch-exit
+    // steps. Consumed (cleared) by the chain on the SAME press it gates;
+    // also cleared on every sketch enter/exit reset to avoid staleness.
+    bool m_dimPopupConsumedEsc = false;
 
     // Sketch grid step in mm (drives both the visual face grid and snap-to-line)
     float m_sketchGridStep = 1.0f;

--- a/src/app/Application.h
+++ b/src/app/Application.h
@@ -63,6 +63,7 @@ class PropertiesPanel;
 class Sketch;
 class SketchSolver;
 class SketchTool;
+struct PendingDimension;
 class EventBus;
 class PluginContext;
 
@@ -346,6 +347,16 @@ private:
     // doesn't match the constraint's requirements. Routed from the toolbar
     // Constraints section; constraints are always opt-in.
     void applySketchConstraint(ConstraintType type);
+
+    // Commit the Dimension tool's resolved pending dimension: one undoable
+    // constraint add (or value+label update when the same pair is already
+    // dimensioned), then open the ##DimEdit popup on it for value entry.
+    void applyPendingDimension();
+
+    // Sketch-space auto anchor of a dimension's label: line/pair midpoint,
+    // circle/arc center, or the midpoint of the point-to-line perpendicular
+    // foot segment. Label offsets are stored relative to this.
+    glm::vec2 dimensionAutoAnchor(const PendingDimension& pd) const;
 
     // Align the orbit camera to look straight at the active sketch's plane in ortho.
     // Called when entering sketch mode / editing an existing sketch.
@@ -650,6 +661,11 @@ private:
     char m_dimEditingBuf[32] = "";
     bool m_dimEditingFocus = false;
     bool m_dimEditingClickedThisFrame = false;
+    // Set by applyPendingDimension() (Dimension tool commit) to defer
+    // ImGui::OpenPopup("##DimEdit") to the viewport's own ImGui window scope
+    // next frame — OpenPopup only works when called from the window that
+    // owns the popup's ID stack, which the app-level commit path isn't in.
+    bool m_dimOpenEditRequested = false;
 
     // Sketch grid step in mm (drives both the visual face grid and snap-to-line)
     float m_sketchGridStep = 1.0f;

--- a/src/app/Application_Dialogs.cpp
+++ b/src/app/Application_Dialogs.cpp
@@ -43,6 +43,7 @@
 #include "ui/ShortcutsPanel.h"
 #include "ui/HelpPanel.h"
 #include "ui/UpdateChecker.h"
+#include "ui/WelcomeScreen.h"
 #include "modeling/Sketch.h"
 #include "modeling/SketchSolver.h"
 #include "modeling/SketchTool.h"
@@ -661,6 +662,19 @@ void Application::renderMirrorPopup() {
 
 void Application::renderUpdatePopup() {
     if (!m_showUpdatePopup) return;
+    // Startup dialogs take turns for the popup-stack level (see the Welcome
+    // screen's render site in Application.cpp run(), and the identical gate
+    // on renderProjectRecoveryPrompt/renderSketchRecoveryPrompt): this popup
+    // and the crash-recovery prompts both call OpenPopup() unconditionally
+    // every frame, and two such raw reopens contending for the same level
+    // closes each other every frame forever — neither ever draws, while the
+    // modal dim still blocks all input (see run()'s comment on this class of
+    // bug). The launch-time update check resolves on a background thread and
+    // can flip m_showUpdatePopup true at ANY frame, including while a
+    // recovery prompt is up — hold off exactly like those prompts hold off
+    // for Welcome, until they've resolved.
+    if (m_welcomeScreen && m_welcomeScreen->isVisible()) return;
+    if (m_pendingProjectRecovery || m_pendingSketchRecovery) return;
 
     ImGui::OpenPopup("Check for Updates");
 

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -7167,6 +7167,8 @@ void Application::renderViewport() {
             if (nCur >= 2) {
                 if (ImGui::MenuItem("Concentric"))
                     applySketchConstraint(ConstraintType::Concentric);
+                if (ImGui::MenuItem("Equal radius"))
+                    applySketchConstraint(ConstraintType::Equal);
             }
             // ImGui automatically greys out an empty submenu, but we want to
             // hint at the cause when nothing matches the selection.

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -258,6 +258,35 @@ glm::vec2 Application::dimensionAutoAnchor(const PendingDimension& pd) const {
                 return 0.25f * (as + ae + bs + be);
             return glm::vec2(0.0f);
         }
+        case ConstraintType::CircleGap: {
+            glm::vec2 cA(0.0f), cB(0.0f);
+            double rA = -1.0, rB = -1.0;
+            auto grab = [&](int id, glm::vec2& ctr, double& r) {
+                for (const auto& c : sk.getCircles())
+                    if (c.id == id) {
+                        const SketchPoint* p = sk.getPoint(c.centerPointId);
+                        if (p) { ctr = p->pos; r = c.radius; }
+                        return;
+                    }
+                for (const auto& a : sk.getArcs())
+                    if (a.id == id) {
+                        const SketchPoint* p = sk.getPoint(a.centerPointId);
+                        if (p) { ctr = p->pos; r = a.radius; }
+                        return;
+                    }
+            };
+            grab(pd.entityA, cA, rA);
+            grab(pd.entityB, cB, rB);
+            if (rA < 0.0 || rB < 0.0) return 0.0f * cA;
+            glm::vec2 d = cB - cA;
+            float len = glm::length(d);
+            if (len < 1e-6f) return 0.5f * (cA + cB);
+            glm::vec2 u = d / len;
+            // Midpoint of the gap: from A's rim to B's rim along the centre line.
+            glm::vec2 rimA = cA + u * static_cast<float>(rA);
+            glm::vec2 rimB = cB - u * static_cast<float>(rB);
+            return 0.5f * (rimA + rimB);
+        }
         default: return glm::vec2(0.0f);
     }
 }
@@ -2782,6 +2811,41 @@ void Application::renderViewport() {
                         std::snprintf(lbl, sizeof(lbl), "%.2f mm", c.value);
                         glm::vec2 midDim = 0.5f * (baseA + baseB);
                         placeLabel(anchor, midDim - anchor, lbl, c, &midDim);
+                    } else if (c.type == ConstraintType::CircleGap) {
+                        // Draw the gap segment between the two facing rims,
+                        // label at its midpoint (the leader runs from there).
+                        auto grab = [&](int id, glm::vec2& ctr, double& r) -> bool {
+                            for (const auto& cc : m_activeSketch->getCircles())
+                                if (cc.id == id) {
+                                    const SketchPoint* p = m_activeSketch->getPoint(cc.centerPointId);
+                                    if (p) { ctr = p->pos; r = cc.radius; return true; }
+                                }
+                            for (const auto& aa : m_activeSketch->getArcs())
+                                if (aa.id == id) {
+                                    const SketchPoint* p = m_activeSketch->getPoint(aa.centerPointId);
+                                    if (p) { ctr = p->pos; r = aa.radius; return true; }
+                                }
+                            return false;
+                        };
+                        glm::vec2 cA, cB; double rA = 0, rB = 0;
+                        if (!grab(c.entityA, cA, rA) || !grab(c.entityB, cB, rB)) continue;
+                        glm::vec2 d = cB - cA;
+                        float len = glm::length(d);
+                        if (len < 1e-6f) continue;
+                        glm::vec2 u = d / len;
+                        glm::vec2 rimA = cA + u * static_cast<float>(rA);
+                        glm::vec2 rimB = cB - u * static_cast<float>(rB);
+                        ImVec2 pA, pB;
+                        if (toImg(dim2world(rimA), pA) && toImg(dim2world(rimB), pB)) {
+                            dl->AddLine(pA, pB, IM_COL32(20, 20, 28, 200), 3.0f);
+                            dl->AddLine(pA, pB, IM_COL32(255, 235, 120, 230), 1.5f);
+                        }
+                        PendingDimension pd;
+                        pd.type = c.type; pd.entityA = c.entityA;
+                        pd.entityB = c.entityB; pd.valid = true;
+                        glm::vec2 anchor = dimensionAutoAnchor(pd);
+                        std::snprintf(lbl, sizeof(lbl), "%.2f mm", c.value);
+                        placeLabel(anchor, glm::vec2(0.0f), lbl, c, &anchor);
                     }
                 }
 

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -2557,16 +2557,24 @@ void Application::renderViewport() {
                 // position when unset (legacy / not yet user-placed). Draws a
                 // thin leader from the anchor to the label whenever the user
                 // has moved it off the auto spot.
+                // `leaderFrom` overrides where a placed label's leader starts
+                // (default: the anchor). DistancePointLine passes its dim
+                // line's midpoint — the offset math must stay anchored on
+                // dimensionAutoAnchor (what applyPendingDimension stored
+                // against), but a leader drawn from that anchor points at the
+                // constraint's pinned corner, not the dimension line.
                 auto placeLabel = [&](glm::vec2 anchor, glm::vec2 autoOff,
-                                      const char* text, const Constraint& c) {
+                                      const char* text, const Constraint& c,
+                                      const glm::vec2* leaderFrom = nullptr) {
                     bool placed = (c.labelOffX != 0.0 || c.labelOffY != 0.0);
                     glm::vec2 lpos = placed
                         ? anchor + glm::vec2(static_cast<float>(c.labelOffX),
                                              static_cast<float>(c.labelOffY))
                         : anchor + autoOff;
                     if (placed) {
+                        glm::vec2 lsrc = leaderFrom ? *leaderFrom : anchor;
                         ImVec2 sa, sb;
-                        if (toImg(dim2world(anchor), sa) && toImg(dim2world(lpos), sb))
+                        if (toImg(dim2world(lsrc), sa) && toImg(dim2world(lpos), sb))
                             dl->AddLine(sa, sb, IM_COL32(255, 235, 120, 90), 1.0f);
                     }
                     drawLabel(lpos, text, c);
@@ -2773,7 +2781,7 @@ void Application::renderViewport() {
                         }
                         std::snprintf(lbl, sizeof(lbl), "%.2f mm", c.value);
                         glm::vec2 midDim = 0.5f * (baseA + baseB);
-                        placeLabel(anchor, midDim - anchor, lbl, c);
+                        placeLabel(anchor, midDim - anchor, lbl, c, &midDim);
                     }
                 }
 

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -240,7 +240,12 @@ glm::vec2 Application::dimensionAutoAnchor(const PendingDimension& pd) const {
                 glm::vec2 d = e - s;
                 float len2 = glm::dot(d, d);
                 if (len2 > 1e-12f) {
-                    float t = glm::dot(p->pos - s, d) / len2; // foot on infinite line
+                    // Foot clamped to the physical segment: the constraint
+                    // measures against the infinite carrier, but a label
+                    // anchored past the segment's end hangs over unrelated
+                    // geometry (rectangle corners made parallel-line dims
+                    // look attached to a third line).
+                    float t = glm::clamp(glm::dot(p->pos - s, d) / len2, 0.0f, 1.0f);
                     glm::vec2 foot = s + d * t;
                     return 0.5f * (p->pos + foot);
                 }

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -2546,6 +2546,26 @@ void Application::renderViewport() {
                         ImGui::OpenPopup("##DimEdit");
                     }
                 };
+                // Resolves a constraint's label position from its stored
+                // offset (Constraint::labelOffX/Y, relative to the type's
+                // geometric anchor — see dimensionAutoAnchor) or the auto
+                // position when unset (legacy / not yet user-placed). Draws a
+                // thin leader from the anchor to the label whenever the user
+                // has moved it off the auto spot.
+                auto placeLabel = [&](glm::vec2 anchor, glm::vec2 autoOff,
+                                      const char* text, const Constraint& c) {
+                    bool placed = (c.labelOffX != 0.0 || c.labelOffY != 0.0);
+                    glm::vec2 lpos = placed
+                        ? anchor + glm::vec2(static_cast<float>(c.labelOffX),
+                                             static_cast<float>(c.labelOffY))
+                        : anchor + autoOff;
+                    if (placed) {
+                        ImVec2 sa, sb;
+                        if (toImg(dim2world(anchor), sa) && toImg(dim2world(lpos), sb))
+                            dl->AddLine(sa, sb, IM_COL32(255, 235, 120, 90), 1.0f);
+                    }
+                    drawLabel(lpos, text, c);
+                };
                 char lbl[40];
                 for (const auto& c : m_activeSketch->getConstraints()) {
                     if (c.type == ConstraintType::Distance) {
@@ -2566,7 +2586,7 @@ void Application::renderViewport() {
                             perp = perp / pl * off;
                         }
                         std::snprintf(lbl, sizeof(lbl), "%.2f mm", c.value);
-                        drawLabel(mid + perp, lbl, c);
+                        placeLabel(mid, perp, lbl, c);
                     } else if (c.type == ConstraintType::Radius) {
                         glm::vec2 center(0.0f);
                         float radius = 1.0f;
@@ -2596,15 +2616,15 @@ void Application::renderViewport() {
                             }
                         }
                         if (!found) continue;
-                        // Place the label tangentially outside the circle (up
+                        // Auto label sits tangentially outside the circle (up
                         // and to the right) so the centre stays clear for
                         // concentric-circle drawing. Offset is the radius + a
                         // small constant so it floats just past the perimeter.
-                        glm::vec2 labelPos = center +
+                        glm::vec2 autoOff =
                             glm::vec2(0.7071f, 0.7071f) * (radius + 1.2f);
                         std::snprintf(lbl, sizeof(lbl), "\xC3\x98 %.2f mm",
                                       c.value * 2.0);
-                        drawLabel(labelPos, lbl, c);
+                        placeLabel(center, autoOff, lbl, c);
                     } else if (c.type == ConstraintType::Angle) {
                         // SolidWorks-style angle dim: find the vertex where the
                         // two constrained lines meet, draw a small arc spanning
@@ -2682,13 +2702,132 @@ void Application::renderViewport() {
                                             0, 1.5f);
                         }
 
-                        // Label hugs the outside of the arc midpoint.
+                        // Auto label hugs the outside of the arc midpoint.
                         float midA = angA + diff * 0.5f;
                         glm::vec2 labelPos = vertex +
                             glm::vec2(std::cos(midA), std::sin(midA)) * (arcR + 2.5f);
                         float deg = std::abs(static_cast<float>(diff * 180.0 / M_PI));
                         std::snprintf(lbl, sizeof(lbl), "%.1f\xC2\xB0", deg);
-                        drawLabel(labelPos, lbl, c);
+                        // The stored offset is relative to dimensionAutoAnchor's
+                        // Angle anchor (mean of all four line endpoints), NOT
+                        // `vertex` — applyPendingDimension() computed it that
+                        // way, so the leader/placed-position math has to match
+                        // or a placed label would drift from where it was
+                        // dropped. autoOff folds that mismatch away: it's
+                        // defined so anchor + autoOff == labelPos exactly,
+                        // reproducing today's arc-hugging auto placement
+                        // whenever the constraint has no stored offset.
+                        glm::vec2 angleAnchor =
+                            0.25f * (aS->pos + aE->pos + bS->pos + bE->pos);
+                        glm::vec2 autoOff = labelPos - angleAnchor;
+                        placeLabel(angleAnchor, autoOff, lbl, c);
+                    } else if (c.type == ConstraintType::DistancePointLine) {
+                        // Validate the entities exist before trusting
+                        // dimensionAutoAnchor's result — it silently returns
+                        // (0,0) on a dangling id, which would otherwise plant
+                        // a stray label at the sketch origin.
+                        const SketchPoint* dp = m_activeSketch->getPoint(c.entityA);
+                        const SketchLine* dpLine = nullptr;
+                        for (const auto& l : m_activeSketch->getLines())
+                            if (l.id == c.entityB) { dpLine = &l; break; }
+                        if (!dp || !dpLine) continue;
+                        PendingDimension pd;
+                        pd.type = c.type; pd.entityA = c.entityA;
+                        pd.entityB = c.entityB; pd.valid = true;
+                        glm::vec2 anchor = dimensionAutoAnchor(pd);
+                        std::snprintf(lbl, sizeof(lbl), "%.2f mm", c.value);
+                        placeLabel(anchor, glm::vec2(2.0f, 2.0f), lbl, c);
+                    }
+                }
+
+                // Dimension tool feedback: highlight the hovered pickable
+                // entity while picking, and ghost the pending label at the
+                // cursor (with a leader from its anchor) once enough entities
+                // are picked to resolve a dimension.
+                if (m_sketchTool->getMode() == SketchToolMode::Dimension) {
+                    ImVec2 mp = ImGui::GetMousePos();
+                    glm::vec2 sketchCursor = screenToSketch(
+                        mp.x - imgMin.x, mp.y - imgMin.y, imgSize.x, imgSize.y);
+                    DimPick hov = m_sketchTool->dimHitTest(sketchCursor);
+                    if (hov.kind == DimEntityKind::Point) {
+                        const SketchPoint* p = m_activeSketch->getPoint(hov.id);
+                        ImVec2 sp;
+                        if (p && toImg(dim2world(p->pos), sp))
+                            dl->AddCircle(sp, 7.0f, IM_COL32(255, 235, 120, 255), 0, 2.0f);
+                    } else if (hov.kind == DimEntityKind::Line) {
+                        for (const auto& l : m_activeSketch->getLines()) {
+                            if (l.id != hov.id) continue;
+                            const SketchPoint* a = m_activeSketch->getPoint(l.startPointId);
+                            const SketchPoint* b = m_activeSketch->getPoint(l.endPointId);
+                            ImVec2 sa, sb;
+                            if (a && b && toImg(dim2world(a->pos), sa) &&
+                                toImg(dim2world(b->pos), sb))
+                                dl->AddLine(sa, sb, IM_COL32(255, 235, 120, 200), 3.0f);
+                            break;
+                        }
+                    } else if (hov.kind == DimEntityKind::Circle ||
+                               hov.kind == DimEntityKind::Arc) {
+                        glm::vec2 hCenter(0.0f);
+                        float hRadius = 0.0f;
+                        bool hFound = false;
+                        if (hov.kind == DimEntityKind::Circle) {
+                            for (const auto& circ : m_activeSketch->getCircles())
+                                if (circ.id == hov.id) {
+                                    const SketchPoint* cp = m_activeSketch->getPoint(circ.centerPointId);
+                                    if (cp) {
+                                        hCenter = cp->pos;
+                                        hRadius = static_cast<float>(circ.radius);
+                                        hFound = true;
+                                    }
+                                    break;
+                                }
+                        } else {
+                            for (const auto& arc : m_activeSketch->getArcs())
+                                if (arc.id == hov.id) {
+                                    const SketchPoint* cp = m_activeSketch->getPoint(arc.centerPointId);
+                                    if (cp) {
+                                        hCenter = cp->pos;
+                                        hRadius = static_cast<float>(arc.radius);
+                                        hFound = true;
+                                    }
+                                    break;
+                                }
+                        }
+                        if (hFound) {
+                            // Screen-space radius: project the center and a
+                            // point one radius away along the sketch plane's
+                            // X axis, then measure the pixel span between
+                            // them (the plane may be tilted/scaled on screen).
+                            ImVec2 sc, sr;
+                            if (toImg(dim2world(hCenter), sc) &&
+                                toImg(dim2world(hCenter + glm::vec2(hRadius, 0.0f)), sr)) {
+                                float screenR = std::hypot(sr.x - sc.x, sr.y - sc.y);
+                                dl->AddCircle(sc, screenR, IM_COL32(255, 235, 120, 255), 0, 2.0f);
+                            }
+                        }
+                    }
+
+                    const PendingDimension& pend = m_sketchTool->getPendingDimension();
+                    if (pend.valid &&
+                        (m_sketchTool->getDimPhase() == DimPhase::PlaceLabel ||
+                         m_sketchTool->getDimPhase() == DimPhase::PickSecondOrPlace)) {
+                        char gbuf[40];
+                        if (pend.type == ConstraintType::Angle)
+                            std::snprintf(gbuf, sizeof(gbuf), "%.1f\xC2\xB0",
+                                          std::abs(pend.measured) * 180.0 / M_PI);
+                        else if (pend.type == ConstraintType::Radius)
+                            std::snprintf(gbuf, sizeof(gbuf), "\xC3\x98%.2f",
+                                          pend.measured * 2.0);
+                        else
+                            std::snprintf(gbuf, sizeof(gbuf), "%.2f mm", pend.measured);
+                        glm::vec2 ganchor = dimensionAutoAnchor(pend);
+                        ImVec2 sa, sc;
+                        if (toImg(dim2world(ganchor), sa) &&
+                            toImg(dim2world(sketchCursor), sc)) {
+                            dl->AddLine(sa, sc, IM_COL32(255, 235, 120, 90), 1.0f);
+                            dl->AddText(ImVec2(sc.x + 8, sc.y - 8),
+                                        IM_COL32(255, 235, 120, 220), gbuf);
+                        }
                     }
                 }
 

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -2964,8 +2964,48 @@ void Application::renderViewport() {
                                 }
                             }
                         }
+                        // A pending diameter (single circle/arc picked, still
+                        // deciding whether a second circle turns it into a
+                        // gap) draws a diameter line ACROSS the circle rather
+                        // than a leader from the centre — a centre-anchored
+                        // leader reads as "measuring from the centre" and hid
+                        // that a second circle click makes a rim gap.
+                        bool drewSpecial = false;
+                        if (pend.type == ConstraintType::Radius) {
+                            glm::vec2 ctr(0.0f); float rad = 0.0f; bool found = false;
+                            for (const auto& circ : m_activeSketch->getCircles())
+                                if (circ.id == pend.entityA) {
+                                    const SketchPoint* cp = m_activeSketch->getPoint(circ.centerPointId);
+                                    if (cp) { ctr = cp->pos; rad = static_cast<float>(circ.radius); found = true; }
+                                    break;
+                                }
+                            for (const auto& arc : m_activeSketch->getArcs())
+                                if (arc.id == pend.entityA) {
+                                    const SketchPoint* cp = m_activeSketch->getPoint(arc.centerPointId);
+                                    if (cp) { ctr = cp->pos; rad = static_cast<float>(arc.radius); found = true; }
+                                    break;
+                                }
+                            if (found) {
+                                // Diameter line oriented toward the cursor.
+                                glm::vec2 d = sketchCursor - ctr;
+                                float len = glm::length(d);
+                                glm::vec2 u = (len > 1e-6f) ? d / len : glm::vec2(1.0f, 0.0f);
+                                ImVec2 e1, e2;
+                                if (toImg(dim2world(ctr - u * rad), e1) &&
+                                    toImg(dim2world(ctr + u * rad), e2)) {
+                                    dl->AddLine(e1, e2, IM_COL32(20, 20, 28, 200), 3.0f);
+                                    dl->AddLine(e1, e2, IM_COL32(255, 235, 120, 230), 1.5f);
+                                    ImVec2 sc;
+                                    if (toImg(dim2world(sketchCursor), sc))
+                                        dl->AddText(ImVec2(sc.x + 8, sc.y - 8),
+                                                    IM_COL32(255, 235, 120, 220), gbuf);
+                                    drewSpecial = true;
+                                }
+                            }
+                        }
                         ImVec2 sa, sc;
-                        if (toImg(dim2world(ganchor), sa) &&
+                        if (!drewSpecial &&
+                            toImg(dim2world(ganchor), sa) &&
                             toImg(dim2world(sketchCursor), sc)) {
                             dl->AddLine(sa, sc, IM_COL32(255, 235, 120, 90), 1.0f);
                             dl->AddText(ImVec2(sc.x + 8, sc.y - 8),

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -197,6 +197,76 @@ void Application::gizmoPreviewApply(const glm::mat4& m) {
     }
 }
 
+// Does this Radius constraint measure an ARC (rather than a circle)?
+//
+// Drafting convention splits the two: an arc is called out by RADIUS ("R 10"),
+// a full circle by DIAMETER ("Ø 20"). Constraint::value stores a radius for
+// both, so the label, the edit-popup prefill, and the popup's commit all have
+// to agree on which convention applies — hence one helper rather than three
+// copies of the scan. Non-Radius types are never arc radii.
+static bool constraintIsArcRadiusIn(const Sketch& sk, const Constraint& c) {
+    if (c.type != ConstraintType::Radius) return false;
+    for (const auto& circ : sk.getCircles())
+        if (circ.id == c.entityA) return false; // a circle wins
+    for (const auto& arc : sk.getArcs())
+        if (arc.id == c.entityA) return true;
+    return false;
+}
+
+// Recover the two comparable entities behind a dimension, so the edit popup
+// can offer "Make equal" (equal length for two lines, equal radius for two
+// circles/arcs). Returns false when the dimension has no such pair.
+//
+// Derived rather than stored: every dimension that came from a two-entity pick
+// still carries enough to reconstruct the pair, so no extra state has to be
+// threaded through PendingDimension and the option stays available when the
+// user re-opens an OLD dimension's popup, not just a freshly placed one.
+static bool dimensionEqualPair(const Sketch& sk, const Constraint& c,
+                               int& outA, int& outB) {
+    auto isCurveId = [&sk](int id) {
+        for (const auto& x : sk.getCircles()) if (x.id == id) return true;
+        for (const auto& x : sk.getArcs())    if (x.id == id) return true;
+        return false;
+    };
+    switch (c.type) {
+        case ConstraintType::Angle:      // entityA/entityB are both line ids
+        case ConstraintType::CircleGap:  // entityA/entityB are both curve ids
+            outA = c.entityA; outB = c.entityB;
+            return outA >= 0 && outB >= 0 && outA != outB;
+        case ConstraintType::DistancePointLine: {
+            // entityA is a POINT on the second line, entityB the first line.
+            // Recover the second line as the one owning that point — that is
+            // exactly how resolveDimension's parallel branch built the pair.
+            for (const auto& l : sk.getLines()) {
+                if (l.id == c.entityB) continue;
+                if (l.startPointId == c.entityA || l.endPointId == c.entityA) {
+                    outA = c.entityB; outB = l.id;
+                    return true;
+                }
+            }
+            return false;
+        }
+        case ConstraintType::Distance: {
+            // Only meaningful when both ends are circle/arc centres (a
+            // centre-to-centre dim); two bare points have no "length" to
+            // equalise. Map each centre back to its curve.
+            auto curveOfCentre = [&sk](int ptId) {
+                for (const auto& x : sk.getCircles())
+                    if (x.centerPointId == ptId) return x.id;
+                for (const auto& x : sk.getArcs())
+                    if (x.centerPointId == ptId) return x.id;
+                return -1;
+            };
+            int ca = curveOfCentre(c.entityA), cb = curveOfCentre(c.entityB);
+            if (ca < 0 || cb < 0 || ca == cb) return false;
+            outA = ca; outB = cb;
+            return isCurveId(ca) && isCurveId(cb);
+        }
+        default:
+            return false;
+    }
+}
+
 // Sketch-space auto anchor of a dimension's label: line/pair midpoint,
 // circle/arc center, or the midpoint of the point-to-line perpendicular foot
 // segment. Label offsets (Constraint::labelOffX/Y) are stored relative to
@@ -2557,7 +2627,11 @@ void Application::renderViewport() {
                     ImU32 bg = hovered ? IM_COL32(45, 45, 60, 235)
                                        : IM_COL32(20, 20, 28, 220);
                     dl->AddRectFilled(rMin, rMax, bg, 3.0f);
-                    dl->AddText(tp, IM_COL32(255, 235, 120, 255), text);
+                    // Driving dimensions in the usual amber; reference ones in
+                    // a muted grey so a glance separates "this number controls
+                    // the shape" from "this number just reports it".
+                    dl->AddText(tp, c.isDriving ? IM_COL32(255, 235, 120, 255)
+                                                : IM_COL32(170, 178, 190, 255), text);
                     // Click → open edit popup. Skipped if we're already
                     // editing this same constraint to avoid re-triggering
                     // the open every frame the popup is up.
@@ -2568,9 +2642,11 @@ void Application::renderViewport() {
                             std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf),
                                           "%.2f", c.value * 180.0 / M_PI);
                         } else if (c.type == ConstraintType::Radius) {
-                            // Edited as diameter to match the label.
-                            std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf),
-                                          "%.2f", c.value * 2.0);
+                            // Edited in whatever unit the label shows: radius
+                            // for an arc (R), diameter for a circle (Ø).
+                            std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf), "%.2f",
+                                          constraintIsArcRadiusIn(*m_activeSketch, c)
+                                              ? c.value : c.value * 2.0);
                         } else {
                             std::snprintf(m_dimEditingBuf, sizeof(m_dimEditingBuf),
                                           "%.2f", c.value);
@@ -2606,7 +2682,17 @@ void Application::renderViewport() {
                         if (toImg(dim2world(lsrc), sa) && toImg(dim2world(lpos), sb))
                             dl->AddLine(sa, sb, IM_COL32(255, 235, 120, 90), 1.0f);
                     }
-                    drawLabel(lpos, text, c);
+                    // Reference (non-driving) dimensions are bracketed, the
+                    // standard drafting notation for a measurement that does
+                    // not control the geometry. One place, so every dimension
+                    // type picks it up — drawLabel handles the colour.
+                    if (!c.isDriving) {
+                        char ref[48];
+                        std::snprintf(ref, sizeof(ref), "[%s]", text);
+                        drawLabel(lpos, ref, c);
+                    } else {
+                        drawLabel(lpos, text, c);
+                    }
                 };
                 char lbl[40];
                 for (const auto& c : m_activeSketch->getConstraints()) {
@@ -2664,8 +2750,12 @@ void Application::renderViewport() {
                         // small constant so it floats just past the perimeter.
                         glm::vec2 autoOff =
                             glm::vec2(0.7071f, 0.7071f) * (radius + 1.2f);
-                        std::snprintf(lbl, sizeof(lbl), "\xC3\x98 %.2f mm",
-                                      c.value * 2.0);
+                        // Drafting convention: arcs read as R, circles as Ø.
+                        if (constraintIsArcRadiusIn(*m_activeSketch, c))
+                            std::snprintf(lbl, sizeof(lbl), "R %.2f mm", c.value);
+                        else
+                            std::snprintf(lbl, sizeof(lbl), "\xC3\x98 %.2f mm",
+                                          c.value * 2.0);
                         placeLabel(center, autoOff, lbl, c);
                     } else if (c.type == ConstraintType::Angle) {
                         // SolidWorks-style angle dim: find the vertex where the
@@ -3078,10 +3168,22 @@ void Application::renderViewport() {
                                     if (cn.type == ConstraintType::Angle) {
                                         cn.value = v * M_PI / 180.0;
                                     } else if (cn.type == ConstraintType::Radius) {
-                                        if (v > 0.0) cn.value = v * 0.5;
+                                        // Circles are typed as diameter; arcs
+                                        // as radius, matching the R/Ø label.
+                                        if (v > 0.0)
+                                            cn.value = constraintIsArcRadiusIn(*m_activeSketch, cn)
+                                                           ? v : v * 0.5;
                                     } else if (v > 0.0) {
                                         cn.value = v;
                                     }
+                                    // Typing a number is an explicit statement
+                                    // that this measurement should CONTROL the
+                                    // geometry, so it promotes a reference
+                                    // dimension to driving. Placing a dimension
+                                    // stays a pure measurement; committing a
+                                    // value is what opts into driving.
+                                    if (constraintSupportsReference(cn.type))
+                                        cn.isDriving = true;
                                     break;
                                 }
                                 if (m_sketchSolver) m_sketchSolver->solve(*m_activeSketch);
@@ -3090,6 +3192,67 @@ void Application::renderViewport() {
                             m_meshesDirty = true;
                             m_dimEditingId = -1;
                             ImGui::CloseCurrentPopup();
+                        }
+                        // Driving toggle. A dimension placed by the Dimension
+                        // tool starts as reference (measures only); this is
+                        // where the user promotes it to control the geometry,
+                        // or demotes a driving one back to an annotation.
+                        // Hidden for geometric constraints, where "reference"
+                        // is meaningless (see constraintSupportsReference).
+                        {
+                            Constraint* cur = nullptr;
+                            for (auto& cn : m_activeSketch->getMutableConstraints())
+                                if (cn.id == m_dimEditingId) { cur = &cn; break; }
+                            if (cur && constraintSupportsReference(cur->type)) {
+                                ImGui::Spacing();
+                                bool drv = cur->isDriving;
+                                if (ImGui::Checkbox("Driving", &drv)) {
+                                    recordSketchMutation([&]{
+                                        for (auto& cn : m_activeSketch->getMutableConstraints()) {
+                                            if (cn.id != m_dimEditingId) continue;
+                                            cn.isDriving = drv;
+                                            break;
+                                        }
+                                        if (m_sketchSolver) m_sketchSolver->solve(*m_activeSketch);
+                                    });
+                                    markDirty();
+                                    m_meshesDirty = true;
+                                }
+                                ImGui::SameLine();
+                                ImGui::TextDisabled(drv ? "(controls geometry)"
+                                                        : "(measures only)");
+                            }
+                            // "Make equal" — converts a two-entity dimension
+                            // into an Equal constraint on the same pair (equal
+                            // length for lines, equal radius for circles/arcs).
+                            // Equal carries no measurement, so it is always a
+                            // driving constraint; the numeric dimension it
+                            // replaces is consumed by the conversion.
+                            int eqA = -1, eqB = -1;
+                            if (cur && dimensionEqualPair(*m_activeSketch, *cur, eqA, eqB)) {
+                                ImGui::Spacing();
+                                if (ImGui::Button("Make equal")) {
+                                    int convId = m_dimEditingId;
+                                    recordSketchMutation([&]{
+                                        for (auto& cn : m_activeSketch->getMutableConstraints()) {
+                                            if (cn.id != convId) continue;
+                                            cn.type = ConstraintType::Equal;
+                                            cn.entityA = eqA;
+                                            cn.entityB = eqB;
+                                            cn.value = 0.0;
+                                            cn.isDriving = true;
+                                            break;
+                                        }
+                                        if (m_sketchSolver) m_sketchSolver->solve(*m_activeSketch);
+                                    });
+                                    markDirty();
+                                    m_meshesDirty = true;
+                                    m_dimEditingId = -1;
+                                    ImGui::CloseCurrentPopup();
+                                }
+                                ImGui::SameLine();
+                                ImGui::TextDisabled("(equal length / radius)");
+                            }
                         }
                         // Delete removes the dimension constraint entirely, as
                         // one undoable step ("Remove …" in History).
@@ -6347,6 +6510,10 @@ void Application::renderViewport() {
                             m_sketchTool->onMouseDown(sketchCoord, false);
                             if (m_sketchTool->dimReadyToCommit())
                                 applyPendingDimension();
+                            // Surface a refused pick instead of letting the
+                            // click look like it simply missed the geometry.
+                            if (const char* why = m_sketchTool->consumeDimRejection())
+                                showToast(why, 2.5);
                         }
                     } else if (materializr::touchMode()) {
                         // A held circle awaiting its ✗/✓ bubble: drawing the

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -2836,6 +2836,23 @@ void Application::renderViewport() {
                 // edit and leaves the constraint unchanged. Enter commits the
                 // typed value, re-runs the solver, and marks the project dirty.
                 if (m_dimEditingId >= 0) {
+                    // Latch "the popup just consumed an Escape" BEFORE
+                    // BeginPopup below can act on it and clear
+                    // m_dimEditingId — the global Escape chain in
+                    // handleShortcuts() runs AFTER this render pass, so by
+                    // then m_dimEditingId would already read -1 and the
+                    // chain would wrongly treat the press as a fresh
+                    // Dimension-mode / sketch-exit step instead of "just
+                    // closed the popup". Covers both ImGui Escape behaviours
+                    // here: while the InputText has focus, the first Escape
+                    // only defocuses it (BeginPopup still returns true,
+                    // m_dimEditingId unchanged) — this block is still
+                    // entered next frame with the popup still up, so a
+                    // second Escape (the one that actually closes it) is
+                    // caught the same way.
+                    if (ImGui::IsKeyPressed(ImGuiKey_Escape, false)) {
+                        m_dimPopupConsumedEsc = true;
+                    }
                     // Restore normal padding — the viewport window's
                     // WindowPadding(0,0) is still pushed here, and the popup
                     // captures the style at its own Begin.

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -5973,6 +5973,13 @@ void Application::renderViewport() {
                         for (auto& [id, orig] : m_sketchGizmoOriginals)
                             m_activeSketch->movePoint(id, orig + delta);
                     }
+                    // Re-solve so dimensional/geometric constraints hold while
+                    // the gizmo drags geometry — otherwise a constrained
+                    // circle/line could be dragged off its dimension and the
+                    // stale value would keep displaying (the select-drag path
+                    // already solves via SketchTool::onMouseMove; the gizmo
+                    // path bypassed it).
+                    if (m_sketchSolver) m_sketchSolver->solve(*m_activeSketch);
 
                     if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
                         if (m_sketchGizmoHandle == SketchGizmoHandle::Rotate) {

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -197,6 +197,66 @@ void Application::gizmoPreviewApply(const glm::mat4& m) {
     }
 }
 
+// Sketch-space auto anchor of a dimension's label: line/pair midpoint,
+// circle/arc center, or the midpoint of the point-to-line perpendicular foot
+// segment. Label offsets (Constraint::labelOffX/Y) are stored relative to
+// this, so it has to stay in sync with the dimension-label render pass below.
+glm::vec2 Application::dimensionAutoAnchor(const PendingDimension& pd) const {
+    if (!m_activeSketch || !pd.valid) return glm::vec2(0.0f);
+    const Sketch& sk = *m_activeSketch;
+    auto lineEnds = [&sk](int id, glm::vec2& s, glm::vec2& e) {
+        for (const auto& l : sk.getLines())
+            if (l.id == id) {
+                const SketchPoint* sp = sk.getPoint(l.startPointId);
+                const SketchPoint* ep = sk.getPoint(l.endPointId);
+                if (!sp || !ep) return false;
+                s = sp->pos; e = ep->pos; return true;
+            }
+        return false;
+    };
+    switch (pd.type) {
+        case ConstraintType::Distance: {
+            const SketchPoint* a = sk.getPoint(pd.entityA);
+            const SketchPoint* b = sk.getPoint(pd.entityB);
+            return (a && b) ? 0.5f * (a->pos + b->pos) : glm::vec2(0.0f);
+        }
+        case ConstraintType::Radius: {
+            for (const auto& c : sk.getCircles())
+                if (c.id == pd.entityA) {
+                    const SketchPoint* ctr = sk.getPoint(c.centerPointId);
+                    if (ctr) return ctr->pos;
+                }
+            for (const auto& a : sk.getArcs())
+                if (a.id == pd.entityA) {
+                    const SketchPoint* ctr = sk.getPoint(a.centerPointId);
+                    if (ctr) return ctr->pos;
+                }
+            return glm::vec2(0.0f);
+        }
+        case ConstraintType::DistancePointLine: {
+            const SketchPoint* p = sk.getPoint(pd.entityA);
+            glm::vec2 s, e;
+            if (p && lineEnds(pd.entityB, s, e)) {
+                glm::vec2 d = e - s;
+                float len2 = glm::dot(d, d);
+                if (len2 > 1e-12f) {
+                    float t = glm::dot(p->pos - s, d) / len2; // foot on infinite line
+                    glm::vec2 foot = s + d * t;
+                    return 0.5f * (p->pos + foot);
+                }
+            }
+            return p ? p->pos : glm::vec2(0.0f);
+        }
+        case ConstraintType::Angle: {
+            glm::vec2 as, ae, bs, be;
+            if (lineEnds(pd.entityA, as, ae) && lineEnds(pd.entityB, bs, be))
+                return 0.25f * (as + ae + bs + be);
+            return glm::vec2(0.0f);
+        }
+        default: return glm::vec2(0.0f);
+    }
+}
+
 void Application::renderViewport() {
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
     ImGuiWindowFlags vpFlags = 0;
@@ -2440,6 +2500,16 @@ void Application::renderViewport() {
                 // Reset the per-frame "click swallowed by a label" flag —
                 // re-evaluated below as labels are drawn and hit-tested.
                 m_dimEditingClickedThisFrame = false;
+                // The Dimension tool's commit path (applyPendingDimension, in
+                // Application.cpp) sets m_dimEditingId + this flag from outside
+                // any ImGui window scope. OpenPopup only takes effect when
+                // called from the window that owns the popup's ID stack, so
+                // defer it to here — same scope as the label-click OpenPopup
+                // calls below.
+                if (m_dimOpenEditRequested) {
+                    ImGui::OpenPopup("##DimEdit");
+                    m_dimOpenEditRequested = false;
+                }
                 auto drawLabel = [&](glm::vec2 pos, const char* text,
                                      const Constraint& c) {
                     ImVec2 sp;
@@ -5895,6 +5965,12 @@ void Application::renderViewport() {
                         // it. Snapshot manually for the drag-commit on mouse-up.
                         m_sketchDragBefore = std::make_shared<Sketch>(*m_activeSketch);
                         recordSketchMutation([&]{ m_sketchTool->onMouseDown(sketchCoord, io.KeyCtrl); });
+                    } else if (m_sketchTool->getMode() == SketchToolMode::Dimension) {
+                        // Picking mutates nothing — no undo record. The commit
+                        // below records the constraint add as one SketchEditOp.
+                        m_sketchTool->onMouseDown(sketchCoord, false);
+                        if (m_sketchTool->dimReadyToCommit())
+                            applyPendingDimension();
                     } else if (materializr::touchMode()) {
                         // A held circle awaiting its ✗/✓ bubble: drawing the
                         // next shape auto-commits it as-released (the bubble

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -2736,12 +2736,44 @@ void Application::renderViewport() {
                         for (const auto& l : m_activeSketch->getLines())
                             if (l.id == c.entityB) { dpLine = &l; break; }
                         if (!dp || !dpLine) continue;
+                        const SketchPoint* ls = m_activeSketch->getPoint(dpLine->startPointId);
+                        const SketchPoint* le = m_activeSketch->getPoint(dpLine->endPointId);
+                        if (!ls || !le) continue;
+                        glm::vec2 seg = le->pos - ls->pos;
+                        float segLen = glm::length(seg);
+                        if (segLen < 1e-6f) continue;
+                        glm::vec2 dirA = seg / segLen;
+                        glm::vec2 nA(-dirA.y, dirA.x);
+                        float sd = glm::dot(dp->pos - ls->pos, nA);
+
                         PendingDimension pd;
                         pd.type = c.type; pd.entityA = c.entityA;
                         pd.entityB = c.entityB; pd.valid = true;
                         glm::vec2 anchor = dimensionAutoAnchor(pd);
+                        bool hasOff = (c.labelOffX != 0.0 || c.labelOffY != 0.0);
+                        glm::vec2 labelPos = hasOff
+                            ? anchor + glm::vec2(static_cast<float>(c.labelOffX),
+                                                 static_cast<float>(c.labelOffY))
+                            : anchor;
+                        // CAD-style perpendicular dimension line, drawn at the
+                        // label's station along the line. The constraint pins
+                        // one endpoint of the measured pair — in rectangles
+                        // that's a corner sitting on a NEIGHBORING edge, and a
+                        // leader pointing there read as "the dim attached to a
+                        // third line". The dim line spans the measured gap
+                        // wherever the label sits instead.
+                        float tL = glm::clamp(glm::dot(labelPos - ls->pos, dirA),
+                                              0.0f, segLen);
+                        glm::vec2 baseA = ls->pos + dirA * tL;
+                        glm::vec2 baseB = baseA + nA * sd;
+                        ImVec2 pA, pB;
+                        if (toImg(dim2world(baseA), pA) && toImg(dim2world(baseB), pB)) {
+                            dl->AddLine(pA, pB, IM_COL32(20, 20, 28, 200), 3.0f);
+                            dl->AddLine(pA, pB, IM_COL32(255, 235, 120, 230), 1.5f);
+                        }
                         std::snprintf(lbl, sizeof(lbl), "%.2f mm", c.value);
-                        placeLabel(anchor, glm::vec2(2.0f, 2.0f), lbl, c);
+                        glm::vec2 midDim = 0.5f * (baseA + baseB);
+                        placeLabel(anchor, midDim - anchor, lbl, c);
                     }
                 }
 
@@ -2826,6 +2858,40 @@ void Application::renderViewport() {
                         else
                             std::snprintf(gbuf, sizeof(gbuf), "%.2f mm", pend.measured);
                         glm::vec2 ganchor = dimensionAutoAnchor(pend);
+                        // Pending point-to-line / parallel-line dims preview
+                        // the same CAD-style perpendicular dimension line the
+                        // committed render draws, following the cursor's
+                        // station — the leader then hugs the dim line rather
+                        // than the corner point carrying the constraint.
+                        if (pend.type == ConstraintType::DistancePointLine) {
+                            const SketchPoint* gp = m_activeSketch->getPoint(pend.entityA);
+                            const SketchLine* gl = nullptr;
+                            for (const auto& l : m_activeSketch->getLines())
+                                if (l.id == pend.entityB) { gl = &l; break; }
+                            const SketchPoint* gs = gl ? m_activeSketch->getPoint(gl->startPointId) : nullptr;
+                            const SketchPoint* ge = gl ? m_activeSketch->getPoint(gl->endPointId) : nullptr;
+                            if (gp && gs && ge) {
+                                glm::vec2 seg = ge->pos - gs->pos;
+                                float segLen = glm::length(seg);
+                                if (segLen > 1e-6f) {
+                                    glm::vec2 dirA = seg / segLen;
+                                    glm::vec2 nA(-dirA.y, dirA.x);
+                                    float sd = glm::dot(gp->pos - gs->pos, nA);
+                                    float tL = glm::clamp(
+                                        glm::dot(sketchCursor - gs->pos, dirA),
+                                        0.0f, segLen);
+                                    glm::vec2 baseA = gs->pos + dirA * tL;
+                                    glm::vec2 baseB = baseA + nA * sd;
+                                    ImVec2 gA, gB;
+                                    if (toImg(dim2world(baseA), gA) &&
+                                        toImg(dim2world(baseB), gB)) {
+                                        dl->AddLine(gA, gB, IM_COL32(20, 20, 28, 200), 3.0f);
+                                        dl->AddLine(gA, gB, IM_COL32(255, 235, 120, 230), 1.5f);
+                                    }
+                                    ganchor = 0.5f * (baseA + baseB);
+                                }
+                            }
+                        }
                         ImVec2 sa, sc;
                         if (toImg(dim2world(ganchor), sa) &&
                             toImg(dim2world(sketchCursor), sc)) {

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -2906,6 +2906,15 @@ void Application::renderViewport() {
                 // BeginPopup returning false (Esc / click-outside) closes the
                 // edit and leaves the constraint unchanged. Enter commits the
                 // typed value, re-runs the solver, and marks the project dirty.
+                // A left click landing while the edit popup is up belongs to
+                // the popup (typically the dismiss-click outside it). The
+                // Dimension tool's routing later this frame checks this flag
+                // so that click can't double as a fresh entity pick — without
+                // it, dismissing the popup over a line started an unwanted
+                // new dimension on that line.
+                m_dimPopupSwallowClick =
+                    (m_dimEditingId >= 0) &&
+                    ImGui::IsMouseClicked(ImGuiMouseButton_Left);
                 if (m_dimEditingId >= 0) {
                     // Latch "the popup just consumed an Escape" BEFORE
                     // BeginPopup below can act on it and clear
@@ -6195,9 +6204,13 @@ void Application::renderViewport() {
                     } else if (m_sketchTool->getMode() == SketchToolMode::Dimension) {
                         // Picking mutates nothing — no undo record. The commit
                         // below records the constraint add as one SketchEditOp.
-                        m_sketchTool->onMouseDown(sketchCoord, false);
-                        if (m_sketchTool->dimReadyToCommit())
-                            applyPendingDimension();
+                        // A click that landed while the ##DimEdit popup was up
+                        // belongs to the popup (dismiss) — never a fresh pick.
+                        if (!m_dimPopupSwallowClick) {
+                            m_sketchTool->onMouseDown(sketchCoord, false);
+                            if (m_sketchTool->dimReadyToCommit())
+                                applyPendingDimension();
+                        }
                     } else if (materializr::touchMode()) {
                         // A held circle awaiting its ✗/✓ bubble: drawing the
                         // next shape auto-commits it as-released (the bubble

--- a/src/app/Application_Viewport.cpp
+++ b/src/app/Application_Viewport.cpp
@@ -3091,6 +3091,24 @@ void Application::renderViewport() {
                             m_dimEditingId = -1;
                             ImGui::CloseCurrentPopup();
                         }
+                        // Delete removes the dimension constraint entirely, as
+                        // one undoable step ("Remove …" in History).
+                        ImGui::Spacing();
+                        if (ImGui::Button("Delete") ||
+                            ImGui::IsKeyPressed(ImGuiKey_Delete, false) ||
+                            ImGui::IsKeyPressed(ImGuiKey_Backspace, false)) {
+                            int delId = m_dimEditingId;
+                            recordSketchMutation([&]{
+                                m_activeSketch->removeConstraint(delId);
+                                if (m_sketchSolver) m_sketchSolver->solve(*m_activeSketch);
+                            });
+                            markDirty();
+                            m_meshesDirty = true;
+                            m_dimEditingId = -1;
+                            ImGui::CloseCurrentPopup();
+                        }
+                        ImGui::SameLine();
+                        ImGui::TextDisabled("(Del)");
                         ImGui::EndPopup();
                     } else {
                         // Popup closed without committing — drop edit state.

--- a/src/io/ProjectIO.cpp
+++ b/src/io/ProjectIO.cpp
@@ -661,22 +661,9 @@ void parseSketchBodyImpl(std::istream& ifs, materializr::Sketch& sk,
                 // Label offsets are trailing optional fields (since the
                 // dimension tool); legacy 6-field K lines default to auto
                 // placement.
-                c.labelOffX = 0.0;
-                c.labelOffY = 0.0;
-                // Extract offsets from end of line if present (8+ fields total)
-                std::istringstream tokens_counter(line);
-                std::string token;
-                int token_count = 0;
-                while (tokens_counter >> token) token_count++;
-                // If we have 9 tokens (K + 8 fields), read the last 2 as offsets
-                if (token_count >= 9) {
-                    // Re-parse to get the last two values
-                    std::istringstream parse_again(line);
-                    std::string dummy;
-                    int dummy_int;
-                    double dummy_val;
-                    parse_again >> dummy >> dummy_int >> dummy_int >> dummy_int >> dummy_int
-                                >> dummy_val >> dummy_val >> c.labelOffX >> c.labelOffY;
+                if (!(s >> c.labelOffX >> c.labelOffY)) {
+                    c.labelOffX = 0.0;
+                    c.labelOffY = 0.0;
                 }
                 c.isSatisfied = false;
                 maxConstraintId = std::max(maxConstraintId, c.id);
@@ -1385,7 +1372,8 @@ void ProjectIO::writeSketchBody(std::ostream& os, const Sketch& sk) {
     for (const auto& c : cns)
         os << "K " << c.id << " " << static_cast<int>(c.type) << " "
            << c.entityA << " " << c.entityB << " "
-           << c.value << " " << c.valueY << "\n";
+           << c.value << " " << c.valueY << " "
+           << c.labelOffX << " " << c.labelOffY << "\n";
 
     os << "SKETCH_END\n";
 }

--- a/src/io/ProjectIO.cpp
+++ b/src/io/ProjectIO.cpp
@@ -323,16 +323,21 @@ ProjectSaveResult ProjectIO::save(const std::string& filePath, const Document& d
         // Constraints: opt-in user-applied sketch constraints. One line each,
         // type stored as the enum's int value (stable as long as we only append
         // to ConstraintType in SketchConstraints.h — which is the policy).
-        // K line format: K id type eA eB value valueY labelOffX labelOffY.
-        // Trailing two fields (label offsets) added for the dimension tool;
-        // readers of older builds ignore trailing tokens.
+        // K line format:
+        //   K id type eA eB value valueY labelOffX labelOffY isDriving
+        // Label offsets were added for the dimension tool; isDriving for
+        // reference (annotation-only) dimensions. Readers of older builds
+        // ignore trailing tokens, so a file written here still loads there
+        // — losing the offsets and treating every dimension as driving,
+        // which is that build's only behaviour anyway.
         const auto& cns = sk->getConstraints();
         ofs << "CONSTRAINT_COUNT " << static_cast<int>(cns.size()) << "\n";
         for (const auto& c : cns) {
             ofs << "K " << c.id << " " << static_cast<int>(c.type) << " "
                 << c.entityA << " " << c.entityB << " "
                 << c.value << " " << c.valueY << " "
-                << c.labelOffX << " " << c.labelOffY << "\n";
+                << c.labelOffX << " " << c.labelOffY << " "
+                << (c.isDriving ? 1 : 0) << "\n";
         }
 
         ofs << "SKETCH_END\n";
@@ -657,6 +662,13 @@ void parseSketchBodyImpl(std::istream& ifs, materializr::Sketch& sk,
                 std::istringstream s(line); std::string t; Constraint c{};
                 int tval = 0;
                 s >> t >> c.id >> tval >> c.entityA >> c.entityB >> c.value >> c.valueY;
+                // Range-check before the cast: a value outside the enum's
+                // range is undefined behaviour, and the solver's switches
+                // have no default arm to absorb it. Drop the constraint
+                // rather than carry a garbage type into the solver.
+                if (tval < static_cast<int>(ConstraintType::Coincident) ||
+                    tval > static_cast<int>(ConstraintType::CircleGap))
+                    continue;
                 c.type = static_cast<ConstraintType>(tval);
                 // Label offsets are trailing optional fields (since the
                 // dimension tool); legacy 6-field K lines default to auto
@@ -665,6 +677,14 @@ void parseSketchBodyImpl(std::istream& ifs, materializr::Sketch& sk,
                     c.labelOffX = 0.0;
                     c.labelOffY = 0.0;
                 }
+                // isDriving is the 9th field (reference dimensions). Absent
+                // in every file written before it existed — and in every
+                // geometric constraint ever written — so the default is
+                // DRIVING, preserving old behaviour exactly. Note the stream
+                // is already in fail state here for a legacy 6-field line, so
+                // this extraction fails too and the default stands.
+                int drv = 1;
+                c.isDriving = (s >> drv) ? (drv != 0) : true;
                 c.isSatisfied = false;
                 maxConstraintId = std::max(maxConstraintId, c.id);
                 sk.addRawConstraint(c);
@@ -1373,7 +1393,8 @@ void ProjectIO::writeSketchBody(std::ostream& os, const Sketch& sk) {
         os << "K " << c.id << " " << static_cast<int>(c.type) << " "
            << c.entityA << " " << c.entityB << " "
            << c.value << " " << c.valueY << " "
-           << c.labelOffX << " " << c.labelOffY << "\n";
+           << c.labelOffX << " " << c.labelOffY << " "
+           << (c.isDriving ? 1 : 0) << "\n";
 
     os << "SKETCH_END\n";
 }

--- a/src/io/ProjectIO.cpp
+++ b/src/io/ProjectIO.cpp
@@ -323,12 +323,16 @@ ProjectSaveResult ProjectIO::save(const std::string& filePath, const Document& d
         // Constraints: opt-in user-applied sketch constraints. One line each,
         // type stored as the enum's int value (stable as long as we only append
         // to ConstraintType in SketchConstraints.h — which is the policy).
+        // K line format: K id type eA eB value valueY labelOffX labelOffY.
+        // Trailing two fields (label offsets) added for the dimension tool;
+        // readers of older builds ignore trailing tokens.
         const auto& cns = sk->getConstraints();
         ofs << "CONSTRAINT_COUNT " << static_cast<int>(cns.size()) << "\n";
         for (const auto& c : cns) {
             ofs << "K " << c.id << " " << static_cast<int>(c.type) << " "
                 << c.entityA << " " << c.entityB << " "
-                << c.value << " " << c.valueY << "\n";
+                << c.value << " " << c.valueY << " "
+                << c.labelOffX << " " << c.labelOffY << "\n";
         }
 
         ofs << "SKETCH_END\n";
@@ -654,6 +658,26 @@ void parseSketchBodyImpl(std::istream& ifs, materializr::Sketch& sk,
                 int tval = 0;
                 s >> t >> c.id >> tval >> c.entityA >> c.entityB >> c.value >> c.valueY;
                 c.type = static_cast<ConstraintType>(tval);
+                // Label offsets are trailing optional fields (since the
+                // dimension tool); legacy 6-field K lines default to auto
+                // placement.
+                c.labelOffX = 0.0;
+                c.labelOffY = 0.0;
+                // Extract offsets from end of line if present (8+ fields total)
+                std::istringstream tokens_counter(line);
+                std::string token;
+                int token_count = 0;
+                while (tokens_counter >> token) token_count++;
+                // If we have 9 tokens (K + 8 fields), read the last 2 as offsets
+                if (token_count >= 9) {
+                    // Re-parse to get the last two values
+                    std::istringstream parse_again(line);
+                    std::string dummy;
+                    int dummy_int;
+                    double dummy_val;
+                    parse_again >> dummy >> dummy_int >> dummy_int >> dummy_int >> dummy_int
+                                >> dummy_val >> dummy_val >> c.labelOffX >> c.labelOffY;
+                }
                 c.isSatisfied = false;
                 maxConstraintId = std::max(maxConstraintId, c.id);
                 sk.addRawConstraint(c);

--- a/src/modeling/Sketch.cpp
+++ b/src/modeling/Sketch.cpp
@@ -514,9 +514,22 @@ int Sketch::addRectangle(glm::vec2 corner1, glm::vec2 corner2) {
 
     // Create 4 lines forming a closed rectangle
     int firstLineId = addLine(p1, p2);
-    addLine(p2, p3);
-    addLine(p3, p4);
-    addLine(p4, p1);
+    int l2 = addLine(p2, p3);
+    int l3 = addLine(p3, p4);
+    int l4 = addLine(p4, p1);
+
+    // Keep the rectangle rigid: top/bottom horizontal, sides vertical. Without
+    // these a later dimension (e.g. a 2 mm gap to another edge) lets the naive
+    // relaxation solver skew the box into a parallelogram, since nothing holds
+    // its sides square. p1→p2 and p3→p4 are horizontal; p2→p3 and p4→p1 vertical.
+    auto addC = [&](ConstraintType t, int a) {
+        Constraint c; c.id = 0; c.type = t; c.entityA = a; c.entityB = -1;
+        c.isSatisfied = true; addConstraint(c);
+    };
+    addC(ConstraintType::Horizontal, firstLineId);
+    addC(ConstraintType::Horizontal, l3);
+    addC(ConstraintType::Vertical, l2);
+    addC(ConstraintType::Vertical, l4);
 
     return firstLineId;
 }

--- a/src/modeling/SketchConstraints.h
+++ b/src/modeling/SketchConstraints.h
@@ -28,6 +28,11 @@ struct Constraint {
     double value = 0.0;  // Distance / Radius / Angle. For Fixed, the X coord.
     double valueY = 0.0; // Y coord of the locked position (Fixed only).
     bool isSatisfied = false;
+    // Sketch-space offset of the dimension label from its auto-computed
+    // anchor. (0,0) = legacy auto placement (pre-offset files and constraints
+    // created without explicit label placement).
+    double labelOffX = 0.0;
+    double labelOffY = 0.0;
 };
 
 } // namespace materializr

--- a/src/modeling/SketchConstraints.h
+++ b/src/modeling/SketchConstraints.h
@@ -16,7 +16,8 @@ enum class ConstraintType {
     Tangent,       // arc/circle tangent to line
     Equal,         // two lines have equal length
     Concentric,    // two circles/arcs share same center
-    Angle          // fixed angle (radians) between two lines
+    Angle,         // fixed angle (radians) between two lines
+    DistancePointLine // fixed perpendicular distance from a point to a line's infinite carrier
 };
 
 struct Constraint {

--- a/src/modeling/SketchConstraints.h
+++ b/src/modeling/SketchConstraints.h
@@ -34,6 +34,29 @@ struct Constraint {
     // created without explicit label placement).
     double labelOffX = 0.0;
     double labelOffY = 0.0;
+
+    // Driving (default) = the solver enforces this constraint and it consumes
+    // a degree of freedom. Reference/driven = the solver ignores it entirely;
+    // it only annotates, re-measuring itself as the geometry moves.
+    //
+    // Defaults to TRUE so every pre-existing constraint — in memory, in old
+    // project files, and every geometric type (Horizontal, Coincident,
+    // Tangent, …) for which "reference" is meaningless — keeps driving
+    // exactly as before. Only the Dimension tool clears it, so a placed
+    // dimension measures without moving anything until the user promotes it
+    // in the label's edit popup. See Application::applyPendingDimension.
+    bool isDriving = true;
 };
+
+// Reference/driven mode is only meaningful for the dimension-bearing types —
+// the ones carrying a numeric value the user reads off the drawing. A
+// geometric relationship (Horizontal, Parallel, Coincident, …) has no
+// measurement to annotate, so it is always driving and the edit popup offers
+// no toggle for it.
+inline bool constraintSupportsReference(ConstraintType t) {
+    return t == ConstraintType::Distance || t == ConstraintType::Radius ||
+           t == ConstraintType::Angle || t == ConstraintType::DistancePointLine ||
+           t == ConstraintType::CircleGap;
+}
 
 } // namespace materializr

--- a/src/modeling/SketchConstraints.h
+++ b/src/modeling/SketchConstraints.h
@@ -17,7 +17,8 @@ enum class ConstraintType {
     Equal,         // two lines have equal length
     Concentric,    // two circles/arcs share same center
     Angle,         // fixed angle (radians) between two lines
-    DistancePointLine // fixed perpendicular distance from a point to a line's infinite carrier
+    DistancePointLine, // fixed perpendicular distance from a point to a line's infinite carrier
+    CircleGap          // fixed rim-to-rim gap between two circles/arcs (centre dist - rA - rB)
 };
 
 struct Constraint {

--- a/src/modeling/SketchEditOp.cpp
+++ b/src/modeling/SketchEditOp.cpp
@@ -103,8 +103,13 @@ std::string SketchEditOp::description() const {
             const Constraint* bMatch = nullptr;
             for (const auto& b : cBefore) if (b.id == cAfter[i].id) { bMatch = &b; break; }
             if (!bMatch) continue;
+            // isDriving too: promoting a reference dimension to driving (or
+            // back) changes nothing numeric, so a value-only comparison would
+            // classify it as "no edit" and the toggle would get no history
+            // step to undo.
             if (std::abs(bMatch->value - cAfter[i].value) > 1e-9 ||
-                std::abs(bMatch->valueY - cAfter[i].valueY) > 1e-9) {
+                std::abs(bMatch->valueY - cAfter[i].valueY) > 1e-9 ||
+                bMatch->isDriving != cAfter[i].isDriving) {
                 char buf[100];
                 if (cAfter[i].type == ConstraintType::Angle) {
                     std::snprintf(buf, sizeof(buf), "Edit Angle %.1f\xC2\xB0 \xE2\x86\x92 %.1f\xC2\xB0",
@@ -286,7 +291,8 @@ static void writeSketchBody(std::ostream& os, const Sketch& sk, int sketchId,
         os << "CONSTRAINT " << c.id << " " << static_cast<int>(c.type)
            << " " << c.entityA << " " << c.entityB
            << " " << c.value << " " << c.valueY
-           << " " << c.labelOffX << " " << c.labelOffY << "\n";
+           << " " << c.labelOffX << " " << c.labelOffY
+           << " " << (c.isDriving ? 1 : 0) << "\n";
     }
 
     os << "SKETCH_END\n";
@@ -375,7 +381,8 @@ void SketchEditOp::renderProperties() {
             for (const auto& b : m_before->getConstraints())
                 if (b.id == c.id) { prev = &b; break; }
             if (prev && std::abs(prev->value - c.value) < 1e-9 &&
-                        std::abs(prev->valueY - c.valueY) < 1e-9)
+                        std::abs(prev->valueY - c.valueY) < 1e-9 &&
+                        prev->isDriving == c.isDriving)
                 continue;
         }
         ImGui::PushID(static_cast<int>(i));

--- a/src/modeling/SketchEditOp.cpp
+++ b/src/modeling/SketchEditOp.cpp
@@ -46,6 +46,7 @@ static const char* constraintName(ConstraintType t) {
         case ConstraintType::Concentric:    return "Concentric";
         case ConstraintType::Angle:         return "Angle";
         case ConstraintType::DistancePointLine: return "Distance to Line";
+        case ConstraintType::CircleGap: return "Circle Gap";
     }
     return "Constraint";
 }

--- a/src/modeling/SketchEditOp.cpp
+++ b/src/modeling/SketchEditOp.cpp
@@ -75,6 +75,10 @@ std::string SketchEditOp::description() const {
                 } else if (c.type == ConstraintType::Angle) {
                     std::snprintf(buf, sizeof(buf), "Add Angle %.1f\xC2\xB0",
                                   c.value * 180.0 / M_PI);
+                } else if (c.type == ConstraintType::DistancePointLine) {
+                    std::snprintf(buf, sizeof(buf), "Add Distance %.2f mm", c.value);
+                } else if (c.type == ConstraintType::CircleGap) {
+                    std::snprintf(buf, sizeof(buf), "Add Gap %.2f mm", c.value);
                 } else {
                     std::snprintf(buf, sizeof(buf), "Add %s", name);
                 }
@@ -109,7 +113,9 @@ std::string SketchEditOp::description() const {
                 } else if (cAfter[i].type == ConstraintType::Radius) {
                     std::snprintf(buf, sizeof(buf), "Edit \xC3\x98 %.2f \xE2\x86\x92 %.2f mm",
                                   bMatch->value * 2.0, cAfter[i].value * 2.0);
-                } else if (cAfter[i].type == ConstraintType::Distance) {
+                } else if (cAfter[i].type == ConstraintType::Distance ||
+                           cAfter[i].type == ConstraintType::DistancePointLine ||
+                           cAfter[i].type == ConstraintType::CircleGap) {
                     std::snprintf(buf, sizeof(buf), "Edit Distance %.2f \xE2\x86\x92 %.2f mm",
                                   bMatch->value, cAfter[i].value);
                 } else {

--- a/src/modeling/SketchEditOp.cpp
+++ b/src/modeling/SketchEditOp.cpp
@@ -277,7 +277,8 @@ static void writeSketchBody(std::ostream& os, const Sketch& sk, int sketchId,
     for (const auto& c : cs) {
         os << "CONSTRAINT " << c.id << " " << static_cast<int>(c.type)
            << " " << c.entityA << " " << c.entityB
-           << " " << c.value << " " << c.valueY << "\n";
+           << " " << c.value << " " << c.valueY
+           << " " << c.labelOffX << " " << c.labelOffY << "\n";
     }
 
     os << "SKETCH_END\n";

--- a/src/modeling/SketchEditOp.cpp
+++ b/src/modeling/SketchEditOp.cpp
@@ -45,6 +45,7 @@ static const char* constraintName(ConstraintType t) {
         case ConstraintType::Equal:         return "Equal";
         case ConstraintType::Concentric:    return "Concentric";
         case ConstraintType::Angle:         return "Angle";
+        case ConstraintType::DistancePointLine: return "Distance to Line";
     }
     return "Constraint";
 }

--- a/src/modeling/SketchSolver.cpp
+++ b/src/modeling/SketchSolver.cpp
@@ -66,6 +66,9 @@ bool SketchSolver::solve(Sketch& sketch, int maxIterations, double tolerance) {
             case ConstraintType::Angle:
                 numEquations += 1; // one angle equation between two lines
                 break;
+            case ConstraintType::DistancePointLine:
+                numEquations += 1;
+                break;
         }
     }
 
@@ -349,6 +352,27 @@ double SketchSolver::computeError(const Constraint& c, const Sketch& sketch) con
             while (diff >  M_PI) diff -= TWO_PI;
             while (diff < -M_PI) diff += TWO_PI;
             return diff;
+        }
+
+        case ConstraintType::DistancePointLine: {
+            // entityA = point id, entityB = line id. Distance is to the
+            // line's INFINITE carrier, matching how CAD dimensions read.
+            const SketchPoint* p = sketch.getPoint(c.entityA);
+            if (!p) return 0.0;
+            for (const auto& line : sketch.getLines()) {
+                if (line.id != c.entityB) continue;
+                const SketchPoint* a = sketch.getPoint(line.startPointId);
+                const SketchPoint* b = sketch.getPoint(line.endPointId);
+                if (!a || !b) return 0.0;
+                glm::vec2 dir = b->pos - a->pos;
+                float len = glm::length(dir);
+                if (len < 1e-10f) return 0.0; // degenerate line: inert, no NaN
+                glm::vec2 rel = p->pos - a->pos;
+                double dist = std::abs(static_cast<double>(dir.x) * rel.y -
+                                       static_cast<double>(dir.y) * rel.x) / len;
+                return dist - c.value;
+            }
+            return 0.0;
         }
     }
 
@@ -637,6 +661,30 @@ void SketchSolver::applyCorrection(const Constraint& c, Sketch& sketch, double e
             float lenB = glm::length(epB->pos - spB->pos);
             glm::vec2 newDir(std::cos(targetAng), std::sin(targetAng));
             sketch.movePoint(lineB->endPointId, spB->pos + newDir * lenB);
+            break;
+        }
+
+        case ConstraintType::DistancePointLine: {
+            const SketchPoint* p = sketch.getPoint(c.entityA);
+            if (!p) return;
+            for (const auto& line : sketch.getLines()) {
+                if (line.id != c.entityB) continue;
+                const SketchPoint* a = sketch.getPoint(line.startPointId);
+                const SketchPoint* b = sketch.getPoint(line.endPointId);
+                if (!a || !b) return;
+                glm::vec2 dir = b->pos - a->pos;
+                float len = glm::length(dir);
+                if (len < 1e-10f) return;
+                dir /= len;
+                glm::vec2 n(-dir.y, dir.x); // unit normal
+                float s = glm::dot(p->pos - a->pos, n); // signed distance
+                if (s < 0.0f) { n = -n; s = -s; }       // n points line → point
+                float corr = (static_cast<float>(c.value) - s) * 0.5f;
+                sketch.movePoint(c.entityA, p->pos + n * corr);
+                sketch.movePoint(line.startPointId, a->pos - n * corr);
+                sketch.movePoint(line.endPointId,   b->pos - n * corr);
+                return;
+            }
             break;
         }
     }

--- a/src/modeling/SketchSolver.cpp
+++ b/src/modeling/SketchSolver.cpp
@@ -69,6 +69,9 @@ bool SketchSolver::solve(Sketch& sketch, int maxIterations, double tolerance) {
             case ConstraintType::DistancePointLine:
                 numEquations += 1;
                 break;
+            case ConstraintType::CircleGap:
+                numEquations += 1;
+                break;
         }
     }
 
@@ -373,6 +376,26 @@ double SketchSolver::computeError(const Constraint& c, const Sketch& sketch) con
                 return dist - c.value;
             }
             return 0.0;
+        }
+
+        case ConstraintType::CircleGap: {
+            // entityA / entityB = circle (or arc) ids. Gap is the rim-to-rim
+            // clearance: |centreA - centreB| - rA - rB.
+            int caPt = -1, cbPt = -1;
+            double rA = 0.0, rB = 0.0;
+            for (const auto& ci : sketch.getCircles()) {
+                if (ci.id == c.entityA) { caPt = ci.centerPointId; rA = ci.radius; }
+                if (ci.id == c.entityB) { cbPt = ci.centerPointId; rB = ci.radius; }
+            }
+            for (const auto& ar : sketch.getArcs()) {
+                if (ar.id == c.entityA) { caPt = ar.centerPointId; rA = ar.radius; }
+                if (ar.id == c.entityB) { cbPt = ar.centerPointId; rB = ar.radius; }
+            }
+            const SketchPoint* pa = sketch.getPoint(caPt);
+            const SketchPoint* pb = sketch.getPoint(cbPt);
+            if (!pa || !pb) return 0.0;
+            double centreDist = glm::length(pa->pos - pb->pos);
+            return (centreDist - rA - rB) - c.value;
         }
     }
 
@@ -697,6 +720,34 @@ void SketchSolver::applyCorrection(const Constraint& c, Sketch& sketch, double e
                 sketch.movePoint(line.endPointId,   b->pos - n * corr);
                 return;
             }
+            break;
+        }
+
+        case ConstraintType::CircleGap: {
+            // Drive the centres apart/together so the rim gap reaches target;
+            // radii are left to their own Radius constraints. Target centre
+            // distance = value + rA + rB.
+            int caPt = -1, cbPt = -1;
+            double rA = 0.0, rB = 0.0;
+            for (const auto& ci : sketch.getCircles()) {
+                if (ci.id == c.entityA) { caPt = ci.centerPointId; rA = ci.radius; }
+                if (ci.id == c.entityB) { cbPt = ci.centerPointId; rB = ci.radius; }
+            }
+            for (const auto& ar : sketch.getArcs()) {
+                if (ar.id == c.entityA) { caPt = ar.centerPointId; rA = ar.radius; }
+                if (ar.id == c.entityB) { cbPt = ar.centerPointId; rB = ar.radius; }
+            }
+            const SketchPoint* pa = sketch.getPoint(caPt);
+            const SketchPoint* pb = sketch.getPoint(cbPt);
+            if (!pa || !pb) return;
+            glm::vec2 diff = pb->pos - pa->pos;
+            float centreDist = glm::length(diff);
+            if (centreDist < 1e-10f) { diff = glm::vec2(1.0f, 0.0f); centreDist = 1.0f; }
+            glm::vec2 dir = diff / centreDist;
+            float targetCentre = static_cast<float>(c.value + rA + rB);
+            float corr = (targetCentre - centreDist) * 0.5f;
+            sketch.movePoint(caPt, pa->pos - dir * corr);
+            sketch.movePoint(cbPt, pb->pos + dir * corr);
             break;
         }
     }

--- a/src/modeling/SketchSolver.cpp
+++ b/src/modeling/SketchSolver.cpp
@@ -283,24 +283,31 @@ double SketchSolver::computeError(const Constraint& c, const Sketch& sketch) con
         }
 
         case ConstraintType::Equal: {
-            // entityA and entityB are line ids; their lengths should be equal
-            const auto& lines = sketch.getLines();
-            float lenA = 0.0f, lenB = 0.0f;
-
-            for (const auto& line : lines) {
-                if (line.id == c.entityA) {
-                    const SketchPoint* sp = sketch.getPoint(line.startPointId);
-                    const SketchPoint* ep = sketch.getPoint(line.endPointId);
-                    if (sp && ep) lenA = glm::length(ep->pos - sp->pos);
-                }
-                if (line.id == c.entityB) {
-                    const SketchPoint* sp = sketch.getPoint(line.startPointId);
-                    const SketchPoint* ep = sketch.getPoint(line.endPointId);
-                    if (sp && ep) lenB = glm::length(ep->pos - sp->pos);
-                }
-            }
-
-            return static_cast<double>(lenA - lenB);
+            // entityA/entityB are EITHER two line ids (equal length) OR two
+            // circle/arc ids (equal radius). Try lengths first, fall back to
+            // radii so one constraint type covers both.
+            auto lineLen = [&](int id, double& out) -> bool {
+                for (const auto& line : sketch.getLines())
+                    if (line.id == id) {
+                        const SketchPoint* sp = sketch.getPoint(line.startPointId);
+                        const SketchPoint* ep = sketch.getPoint(line.endPointId);
+                        if (!sp || !ep) return false;
+                        out = glm::length(ep->pos - sp->pos);
+                        return true;
+                    }
+                return false;
+            };
+            auto curveRad = [&](int id, double& out) -> bool {
+                for (const auto& ci : sketch.getCircles())
+                    if (ci.id == id) { out = ci.radius; return true; }
+                for (const auto& ar : sketch.getArcs())
+                    if (ar.id == id) { out = ar.radius; return true; }
+                return false;
+            };
+            double a = 0.0, b = 0.0;
+            if (lineLen(c.entityA, a) && lineLen(c.entityB, b)) return a - b;
+            if (curveRad(c.entityA, a) && curveRad(c.entityB, b)) return a - b;
+            return 0.0; // mixed / missing: inert
         }
 
         case ConstraintType::Concentric: {
@@ -593,6 +600,31 @@ void SketchSolver::applyCorrection(const Constraint& c, Sketch& sketch, double e
         }
 
         case ConstraintType::Equal: {
+            // Circle/arc pair → equalise radii to their average (radii live in
+            // the shape structs, written through the dedicated setters). Falls
+            // through to the line-length path below when the ids are lines.
+            {
+                auto curveRad = [&](int id, double& out) -> bool {
+                    for (const auto& ci : sketch.getCircles())
+                        if (ci.id == id) { out = ci.radius; return true; }
+                    for (const auto& ar : sketch.getArcs())
+                        if (ar.id == id) { out = ar.radius; return true; }
+                    return false;
+                };
+                auto setRad = [&](int id, double r) {
+                    for (const auto& ci : sketch.getCircles())
+                        if (ci.id == id) { sketch.setCircleRadius(id, r); return; }
+                    for (const auto& ar : sketch.getArcs())
+                        if (ar.id == id) { sketch.setArcRadius(id, r); return; }
+                };
+                double rA = 0.0, rB = 0.0;
+                if (curveRad(c.entityA, rA) && curveRad(c.entityB, rB)) {
+                    double avg = 0.5 * (rA + rB);
+                    setRad(c.entityA, avg);
+                    setRad(c.entityB, avg);
+                    return;
+                }
+            }
             // Make both lines the same length by adjusting their endpoints
             const auto& lines = sketch.getLines();
             const SketchLine* lineA = nullptr;

--- a/src/modeling/SketchSolver.cpp
+++ b/src/modeling/SketchSolver.cpp
@@ -669,6 +669,18 @@ void SketchSolver::applyCorrection(const Constraint& c, Sketch& sketch, double e
             if (!p) return;
             for (const auto& line : sketch.getLines()) {
                 if (line.id != c.entityB) continue;
+                // Defensive identity guard: resolveDimension rejects picking
+                // a point that IS an endpoint of the target line, but a
+                // constraint reaching the solver this way (e.g. loaded from
+                // an older project file, or injected directly) has zero
+                // ACTUAL perpendicular distance (the point sits on the line
+                // by construction) with no correction direction to separate
+                // them along — the ~value/2 nudge below would cancel itself
+                // for the point (it's also one of the endpoints being
+                // corrected) but not for the OTHER endpoint, which gets
+                // flung outward every iteration instead of settling. Leave
+                // it alone; computeError() above returns 0-value harmlessly.
+                if (c.entityA == line.startPointId || c.entityA == line.endPointId) return;
                 const SketchPoint* a = sketch.getPoint(line.startPointId);
                 const SketchPoint* b = sketch.getPoint(line.endPointId);
                 if (!a || !b) return;

--- a/src/modeling/SketchSolver.cpp
+++ b/src/modeling/SketchSolver.cpp
@@ -31,6 +31,11 @@ bool SketchSolver::solve(Sketch& sketch, int maxIterations, double tolerance) {
     int numPoints = sketch.pointCount();
     int numEquations = 0;
     for (const auto& c : constraints) {
+        // Reference (non-driving) dimensions annotate only — they enforce
+        // nothing, so they must not consume a degree of freedom. Counting
+        // them would report a freely-movable sketch as Fully/Over-constrained
+        // the moment a measurement was placed on it.
+        if (!c.isDriving) continue;
         switch (c.type) {
             case ConstraintType::Coincident:
                 numEquations += 2; // x and y must match
@@ -85,11 +90,35 @@ bool SketchSolver::solve(Sketch& sketch, int maxIterations, double tolerance) {
         m_state = SketchState::UnderConstrained;
     }
 
+    // Refresh every reference dimension's stored value from the geometry it
+    // measures. Every computeError branch is defined as (current − target),
+    // so adding the residual back onto the target yields the current reading.
+    // Degenerate branches return 0.0, which leaves the last good value in
+    // place rather than collapsing the label to zero.
+    //
+    // Run at both exits below so a label always shows the post-solve geometry
+    // — a reference dim on a shape that a DRIVING constraint just moved has
+    // to follow it, which is the whole point of an annotation.
+    auto refreshReferenceValues = [&] {
+        for (auto& c : constraints) {
+            if (c.isDriving) continue;
+            c.value += computeError(c, sketch);
+        }
+    };
+
     // Iterative relaxation
     for (int iter = 0; iter < maxIterations; ++iter) {
         double maxError = 0.0;
 
         for (auto& constraint : constraints) {
+            // Reference dimensions are pure annotation: never corrected, and
+            // never allowed to hold up convergence. They are reported
+            // satisfied so the UI doesn't paint them as violated — a
+            // measurement cannot be "unsatisfied".
+            if (!constraint.isDriving) {
+                constraint.isSatisfied = true;
+                continue;
+            }
             double error = computeError(constraint, sketch);
             maxError = std::max(maxError, std::abs(error));
 
@@ -106,10 +135,12 @@ bool SketchSolver::solve(Sketch& sketch, int maxIterations, double tolerance) {
             for (auto& c : constraints) {
                 c.isSatisfied = true;
             }
+            refreshReferenceValues();
             return true;
         }
     }
 
+    refreshReferenceValues();
     return false;
 }
 
@@ -176,11 +207,22 @@ double SketchSolver::computeError(const Constraint& c, const Sketch& sketch) con
         }
 
         case ConstraintType::Radius: {
-            // entityA is circle id
-            const auto& circles = sketch.getCircles();
-            for (const auto& circle : circles) {
+            // entityA is a circle OR an arc id — the Dimension tool creates
+            // this type for both (see resolveDimension's Circle/Arc branches),
+            // and applyCorrection below already writes back through
+            // setCircleRadius / setArcRadius. Scanning circles only made an
+            // arc id return 0.0 ("already satisfied"), so applyCorrection's
+            // arc branch was never reached: the radius never moved while
+            // solve() reported success and the label rendered the typed value
+            // over unchanged geometry.
+            for (const auto& circle : sketch.getCircles()) {
                 if (circle.id == c.entityA) {
                     return circle.radius - c.value;
+                }
+            }
+            for (const auto& arc : sketch.getArcs()) {
+                if (arc.id == c.entityA) {
+                    return arc.radius - c.value;
                 }
             }
             return 0.0;

--- a/src/modeling/SketchSolver.cpp
+++ b/src/modeling/SketchSolver.cpp
@@ -746,10 +746,15 @@ void SketchSolver::applyCorrection(const Constraint& c, Sketch& sketch, double e
                 glm::vec2 n(-dir.y, dir.x); // unit normal
                 float s = glm::dot(p->pos - a->pos, n); // signed distance
                 if (s < 0.0f) { n = -n; s = -s; }       // n points line → point
-                float corr = (static_cast<float>(c.value) - s) * 0.5f;
+                // Move ONLY the measured point, not the reference line. The
+                // line is what we're dimensioning AGAINST (e.g. an already-
+                // placed box's edge); dragging its endpoints too would deform
+                // that box every time a neighbour is dimensioned to it. The
+                // point's own geometry (if part of a constrained rectangle)
+                // gets re-squared by that rectangle's H/V constraints in the
+                // following relaxation passes.
+                float corr = (static_cast<float>(c.value) - s);
                 sketch.movePoint(c.entityA, p->pos + n * corr);
-                sketch.movePoint(line.startPointId, a->pos - n * corr);
-                sketch.movePoint(line.endPointId,   b->pos - n * corr);
                 return;
             }
             break;

--- a/src/modeling/SketchTool.cpp
+++ b/src/modeling/SketchTool.cpp
@@ -3145,10 +3145,11 @@ DimPick SketchTool::hitTestDimEntity(glm::vec2 pos) const {
     if (!m_sketch) return out;
     int nearPt = findCoincidentPoint(pos, -1);
     if (nearPt >= 0) {
-        // Text glyph geometry is not dimensionable.
+        // Text glyph geometry is not dimensionable — fall through and let a
+        // real line/circle/arc at this position win instead (a fromText hit
+        // must not abort the whole hit test).
         const SketchPoint* p = m_sketch->getPoint(nearPt);
-        if (p && !p->fromText) { out = {DimEntityKind::Point, nearPt}; }
-        return out;
+        if (p && !p->fromText) return {DimEntityKind::Point, nearPt};
     }
     const float tol = std::max(m_gridStep * 0.5f, 0.5f) * snapScale();
     // Lines (segment distance), skipping fromText — same math as handleSelectTool.

--- a/src/modeling/SketchTool.cpp
+++ b/src/modeling/SketchTool.cpp
@@ -3194,14 +3194,15 @@ void SketchTool::handleDimensionTool(glm::vec2 pos) {
         case DimPhase::PickFirst: {
             DimPick hit = hitTestDimEntity(pos);
             if (hit.kind == DimEntityKind::None) return;
-            if (hit.kind == DimEntityKind::Circle || hit.kind == DimEntityKind::Arc) {
-                m_dimPending = resolveDimension(*m_sketch, hit, DimPick{});
-                if (m_dimPending.valid) { m_dimPickA = hit; m_dimPhase = DimPhase::PlaceLabel; }
-                return;
-            }
             m_dimPickA = hit;
-            if (hit.kind == DimEntityKind::Line)
-                m_dimPending = resolveDimension(*m_sketch, hit, DimPick{}); // tentative length
+            if (hit.kind == DimEntityKind::Line ||
+                hit.kind == DimEntityKind::Circle ||
+                hit.kind == DimEntityKind::Arc)
+                // Tentative single-entity dim (line length / circle diameter),
+                // but stay open for a second pick: a second circle/arc turns
+                // this into a centre-to-centre distance, a second line into a
+                // distance/angle. Empty space commits the tentative dim.
+                m_dimPending = resolveDimension(*m_sketch, hit, DimPick{});
             else
                 m_dimPending = PendingDimension{}; // lone point: no dim yet
             m_dimPhase = DimPhase::PickSecondOrPlace;
@@ -3257,6 +3258,16 @@ PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPi
         return std::abs(static_cast<double>(d.x) * r.y -
                         static_cast<double>(d.y) * r.x) / len;
     };
+    // Centre point id of a picked circle or arc (both store centerPointId).
+    auto centerPointId = [&sk](DimPick pk) -> int {
+        if (pk.kind == DimEntityKind::Circle)
+            for (const auto& c : sk.getCircles())
+                if (c.id == pk.id) return c.centerPointId;
+        if (pk.kind == DimEntityKind::Arc)
+            for (const auto& a : sk.getArcs())
+                if (a.id == pk.id) return a.centerPointId;
+        return -1;
+    };
 
     // Single-entity dims.
     if (b.kind == DimEntityKind::None) {
@@ -3279,6 +3290,31 @@ PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPi
             return out;
         }
         return out; // lone point: invalid
+    }
+
+    auto isCurve = [](DimEntityKind k) {
+        return k == DimEntityKind::Circle || k == DimEntityKind::Arc;
+    };
+    // Two circles/arcs → centre-to-centre distance (Distance between their
+    // centre points). Same for a curve + a bare point.
+    if (isCurve(a.kind) && isCurve(b.kind)) {
+        int ca = centerPointId(a), cb = centerPointId(b);
+        const SketchPoint* pa = sk.getPoint(ca);
+        const SketchPoint* pb = sk.getPoint(cb);
+        if (pa && pb && ca != cb)
+            out = {ConstraintType::Distance, ca, cb,
+                   static_cast<double>(glm::distance(pa->pos, pb->pos)), true};
+        return out;
+    }
+    if (isCurve(a.kind) && b.kind == DimEntityKind::Point) std::swap(a, b);
+    if (a.kind == DimEntityKind::Point && isCurve(b.kind)) {
+        int cb = centerPointId(b);
+        const SketchPoint* pa = sk.getPoint(a.id);
+        const SketchPoint* pb = sk.getPoint(cb);
+        if (pa && pb && a.id != cb)
+            out = {ConstraintType::Distance, a.id, cb,
+                   static_cast<double>(glm::distance(pa->pos, pb->pos)), true};
+        return out;
     }
 
     // Normalize point-first for the mixed pair.

--- a/src/modeling/SketchTool.cpp
+++ b/src/modeling/SketchTool.cpp
@@ -3320,22 +3320,50 @@ PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPi
         while (ang >  M_PI) ang -= 2.0 * M_PI;
         while (ang < -M_PI) ang += 2.0 * M_PI;
         // Parallel (or anti-parallel) within kDimParallelTolRad: distance
-        // dim. The point is the SECOND line's start, measured to the FIRST
-        // line, so the first pick stays the reference for both branches.
+        // dim, pinned to one of the SECOND line's endpoints measured to the
+        // FIRST line (the first pick stays the reference for both branches).
+        // Endpoint choice matters visually: in chained sketches (rectangles)
+        // an endpoint is a shared corner and its perpendicular foot can land
+        // outside the first segment, hanging the label off to the side over
+        // unrelated geometry. Prefer the endpoint whose foot falls INSIDE
+        // the first segment, and skip endpoints the first line owns
+        // (zero-distance pick in disguise).
         double folded = std::min(std::abs(ang), M_PI - std::abs(ang));
         if (folded <= kDimParallelTolRad) {
             const SketchLine* lb = lineById(b.id);
             const SketchLine* la = lineById(a.id);
-            // Same degenerate-pick hazard as the point+line branch above,
-            // reached a different way: chained near-collinear segments where
-            // the second line's start point IS one of the first line's own
-            // endpoints (a zero-distance pick in disguise).
-            if (lb && la &&
-                (lb->startPointId == la->startPointId || lb->startPointId == la->endPointId))
+            if (!lb || !la) return out;
+            // Chained segments (sharing a vertex) that read as parallel are
+            // near-collinear polyline continuations — a "distance between
+            // these lines" dim is ill-defined there. Reject the pair.
+            if (lb->startPointId == la->startPointId || lb->startPointId == la->endPointId ||
+                lb->endPointId == la->startPointId || lb->endPointId == la->endPointId)
                 return out;
-            double d = perpDist(bs, as, ae);
-            if (lb && d >= 0.0)
-                out = {ConstraintType::DistancePointLine, lb->startPointId, a.id, d, true};
+            glm::vec2 dA = ae - as;
+            float lenA2 = glm::dot(dA, dA); // >0: parallel branch already
+                                            // rejected degenerate lines
+            int bestPt = -1;
+            double bestScore = -1.0;
+            const int candIds[2] = {lb->startPointId, lb->endPointId};
+            const glm::vec2 candPos[2] = {bs, be};
+            for (int i = 0; i < 2; ++i) {
+                if (candIds[i] == la->startPointId || candIds[i] == la->endPointId)
+                    continue;
+                float t = glm::dot(candPos[i] - as, dA) / lenA2;
+                // Score: distance of the foot parameter from the segment
+                // interior — 0 while inside [0,1], grows outside. Lower wins.
+                double outside = (t < 0.0f) ? -t : (t > 1.0f ? t - 1.0f : 0.0);
+                if (bestPt < 0 || outside < bestScore) {
+                    bestPt = i;
+                    bestScore = outside;
+                }
+            }
+            if (bestPt < 0) return out; // both endpoints belong to line A
+            double d = perpDist(candPos[bestPt], as, ae);
+            // d≈0 means the lines are collinear (chained polyline segments):
+            // a zero-distance dim is meaningless and destabilises the solver.
+            if (d >= 1e-6)
+                out = {ConstraintType::DistancePointLine, candIds[bestPt], a.id, d, true};
         } else {
             out = {ConstraintType::Angle, a.id, b.id, ang, true};
         }

--- a/src/modeling/SketchTool.cpp
+++ b/src/modeling/SketchTool.cpp
@@ -3222,14 +3222,27 @@ void SketchTool::handleDimensionTool(glm::vec2 pos) {
         case DimPhase::PickSecondOrPlace: {
             DimPick hit = hitTestDimEntity(pos);
             if (hit.kind != DimEntityKind::None) {
-                if (hit.kind == m_dimPickA.kind && hit.id == m_dimPickA.id) return; // same entity
+                if (hit.kind == m_dimPickA.kind && hit.id == m_dimPickA.id) {
+                    m_dimRejectReason = "Same entity — pick a different one.";
+                    return;
+                }
                 PendingDimension pair = resolveDimension(*m_sketch, m_dimPickA, hit);
-                if (pair.valid) { m_dimPending = pair; m_dimPhase = DimPhase::PlaceLabel; }
-                return; // invalid combo: ignore the click, picks unchanged
+                if (pair.valid) { m_dimPending = pair; m_dimPhase = DimPhase::PlaceLabel; return; }
+                // Invalid combo: picks unchanged, but say why rather than
+                // letting the click look like a miss.
+                m_dimRejectReason =
+                    (m_dimPickA.kind == DimEntityKind::Line && hit.kind == DimEntityKind::Line)
+                        ? "These lines can't be dimensioned to each other "
+                          "(they meet, or are collinear)."
+                        : "That pair can't be dimensioned.";
+                return;
             }
             // Empty space: places the tentative single-entity dim (line length).
-            if (m_dimPending.valid) { m_dimLabelPos = pos; m_dimReady = true; }
-            return; // lone point + empty space: no-op, pick stays pending
+            if (m_dimPending.valid) { m_dimLabelPos = pos; m_dimReady = true; return; }
+            // Lone point + empty space: nothing to measure yet.
+            m_dimRejectReason = "A single point has no dimension — "
+                                "pick a second entity.";
+            return;
         }
         case DimPhase::PlaceLabel: {
             m_dimLabelPos = pos;
@@ -3329,6 +3342,25 @@ PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPi
                    static_cast<double>(glm::distance(pa->pos, pb->pos)) - rA - rB,
                    true};
         return out;
+    }
+
+    // A circle/arc paired with a line or a point dimensions from its CENTRE.
+    // hitTestDimEntity deliberately resolves a centre-point click to the
+    // circle itself (so the rim-gap dim stays reachable), which left the
+    // centre unpickable and made hole-centre-to-edge — the most common
+    // dimension on a machining drawing — impossible to create at all.
+    // Substituting the centre point here recovers it without a modifier key,
+    // so it works the same on touch.
+    if (isCurve(a.kind) && (b.kind == DimEntityKind::Line ||
+                            b.kind == DimEntityKind::Point)) {
+        int ca = centerPointId(a);
+        if (ca < 0) return out;
+        a = {DimEntityKind::Point, ca};
+    } else if (isCurve(b.kind) && (a.kind == DimEntityKind::Line ||
+                                   a.kind == DimEntityKind::Point)) {
+        int cb = centerPointId(b);
+        if (cb < 0) return out;
+        b = {DimEntityKind::Point, cb};
     }
 
     // Normalize point-first for the mixed pair.

--- a/src/modeling/SketchTool.cpp
+++ b/src/modeling/SketchTool.cpp
@@ -3149,7 +3149,18 @@ DimPick SketchTool::hitTestDimEntity(glm::vec2 pos) const {
         // real line/circle/arc at this position win instead (a fromText hit
         // must not abort the whole hit test).
         const SketchPoint* p = m_sketch->getPoint(nearPt);
-        if (p && !p->fromText) return {DimEntityKind::Point, nearPt};
+        if (p && !p->fromText) {
+            // A circle / arc CENTRE resolves to its circle, not the bare
+            // point: dimensioning to a lone centre almost always means the
+            // circle (diameter, or a gap to another circle). Picking the
+            // point would instead make a centre-to-centre distance, which is
+            // rarely what's wanted and blocks the rim-gap dim.
+            for (const auto& c : m_sketch->getCircles())
+                if (c.centerPointId == nearPt) return {DimEntityKind::Circle, c.id};
+            for (const auto& a : m_sketch->getArcs())
+                if (a.centerPointId == nearPt) return {DimEntityKind::Arc, a.id};
+            return {DimEntityKind::Point, nearPt};
+        }
     }
     const float tol = std::max(m_gridStep * 0.5f, 0.5f) * snapScale();
     // Lines (segment distance), skipping fromText — same math as handleSelectTool.

--- a/src/modeling/SketchTool.cpp
+++ b/src/modeling/SketchTool.cpp
@@ -3295,25 +3295,28 @@ PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPi
     auto isCurve = [](DimEntityKind k) {
         return k == DimEntityKind::Circle || k == DimEntityKind::Arc;
     };
-    // Two circles/arcs → centre-to-centre distance (Distance between their
-    // centre points). Same for a curve + a bare point.
+    auto radiusOf = [&sk](DimPick pk) -> double {
+        if (pk.kind == DimEntityKind::Circle)
+            for (const auto& c : sk.getCircles())
+                if (c.id == pk.id) return c.radius;
+        if (pk.kind == DimEntityKind::Arc)
+            for (const auto& a : sk.getArcs())
+                if (a.id == pk.id) return a.radius;
+        return -1.0;
+    };
+    // Two circles/arcs → rim-to-rim gap (centre distance minus both radii),
+    // the clearance a machinist reads between the two circle edges — NOT the
+    // centre distance. entityA/entityB stay the circle ids so the solver can
+    // recompute the gap as radii change.
     if (isCurve(a.kind) && isCurve(b.kind)) {
         int ca = centerPointId(a), cb = centerPointId(b);
         const SketchPoint* pa = sk.getPoint(ca);
         const SketchPoint* pb = sk.getPoint(cb);
-        if (pa && pb && ca != cb)
-            out = {ConstraintType::Distance, ca, cb,
-                   static_cast<double>(glm::distance(pa->pos, pb->pos)), true};
-        return out;
-    }
-    if (isCurve(a.kind) && b.kind == DimEntityKind::Point) std::swap(a, b);
-    if (a.kind == DimEntityKind::Point && isCurve(b.kind)) {
-        int cb = centerPointId(b);
-        const SketchPoint* pa = sk.getPoint(a.id);
-        const SketchPoint* pb = sk.getPoint(cb);
-        if (pa && pb && a.id != cb)
-            out = {ConstraintType::Distance, a.id, cb,
-                   static_cast<double>(glm::distance(pa->pos, pb->pos)), true};
+        double rA = radiusOf(a), rB = radiusOf(b);
+        if (pa && pb && ca != cb && rA >= 0.0 && rB >= 0.0)
+            out = {ConstraintType::CircleGap, a.id, b.id,
+                   static_cast<double>(glm::distance(pa->pos, pb->pos)) - rA - rB,
+                   true};
         return out;
     }
 

--- a/src/modeling/SketchTool.cpp
+++ b/src/modeling/SketchTool.cpp
@@ -3319,12 +3319,11 @@ PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPi
         double ang = std::atan2(db.y, db.x) - std::atan2(da.y, da.x);
         while (ang >  M_PI) ang -= 2.0 * M_PI;
         while (ang < -M_PI) ang += 2.0 * M_PI;
-        // Parallel (or anti-parallel) within 1°: distance dim. The point is
-        // the SECOND line's start, measured to the FIRST line, so the first
-        // pick stays the reference for both branches.
-        const double kParallelTol = 1.0 * M_PI / 180.0;
+        // Parallel (or anti-parallel) within kDimParallelTolRad: distance
+        // dim. The point is the SECOND line's start, measured to the FIRST
+        // line, so the first pick stays the reference for both branches.
         double folded = std::min(std::abs(ang), M_PI - std::abs(ang));
-        if (folded <= kParallelTol) {
+        if (folded <= kDimParallelTolRad) {
             const SketchLine* lb = lineById(b.id);
             const SketchLine* la = lineById(a.id);
             // Same degenerate-pick hazard as the point+line branch above,
@@ -3343,6 +3342,31 @@ PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPi
         return out;
     }
     return out; // circle/arc pairs and circle+point: out of scope
+}
+
+bool SketchTool::linesParallelWithinDimTol(const Sketch& sk, int lineIdA, int lineIdB) {
+    auto lineEnds = [&sk](int id, glm::vec2& s, glm::vec2& e) {
+        for (const auto& l : sk.getLines()) {
+            if (l.id != id) continue;
+            const SketchPoint* sp = sk.getPoint(l.startPointId);
+            const SketchPoint* ep = sk.getPoint(l.endPointId);
+            if (!sp || !ep) return false;
+            s = sp->pos; e = ep->pos;
+            return true;
+        }
+        return false;
+    };
+    glm::vec2 as, ae, bs, be;
+    if (!lineEnds(lineIdA, as, ae) || !lineEnds(lineIdB, bs, be)) return false;
+    glm::vec2 da = ae - as, db = be - bs;
+    if (glm::length(da) < 1e-10f || glm::length(db) < 1e-10f) return false;
+    // Same signed-angle-then-fold test as resolveDimension's line-line
+    // branch, so "parallel enough" means the same thing everywhere.
+    double ang = std::atan2(db.y, db.x) - std::atan2(da.y, da.x);
+    while (ang >  M_PI) ang -= 2.0 * M_PI;
+    while (ang < -M_PI) ang += 2.0 * M_PI;
+    double folded = std::min(std::abs(ang), M_PI - std::abs(ang));
+    return folded <= kDimParallelTolRad;
 }
 
 } // namespace materializr

--- a/src/modeling/SketchTool.cpp
+++ b/src/modeling/SketchTool.cpp
@@ -51,6 +51,8 @@ void SketchTool::setMode(SketchToolMode mode) {
     m_rectDimStage = 0;
     m_rectDimH = 0.0f;
     m_mirrorActive = false; // switching tools aborts any in-progress mirror
+    // Entering or leaving Dimension mode always starts a fresh pick sequence.
+    clearDimState();
 }
 
 SketchToolMode SketchTool::getMode() const {
@@ -64,9 +66,12 @@ void SketchTool::onMouseDown(glm::vec2 pos, bool addToSel) {
     m_charged = {};
     m_hoverCandidate = {};
 
-    // Trim picks by proximity to existing geometry; snapping the cursor first
-    // would pull the click toward unrelated nearby points/edges and pick wrong.
-    glm::vec2 snapped = (m_mode == SketchToolMode::Trim) ? pos : snap(pos);
+    // Trim (and Dimension) pick by proximity to existing geometry; snapping
+    // the cursor first would pull the click toward unrelated nearby
+    // points/edges and pick wrong.
+    glm::vec2 snapped = (m_mode == SketchToolMode::Trim || m_mode == SketchToolMode::Dimension)
+                             ? pos
+                             : snap(pos);
 
     // Rectangle stage-1 (width typed-in, cursor still drives height): the
     // click that commits the second corner should use the LOCKED width on the
@@ -120,12 +125,22 @@ void SketchTool::onMouseDown(glm::vec2 pos, bool addToSel) {
         case SketchToolMode::Svg:
             handleSvgTool(snapped);
             break;
+        case SketchToolMode::Dimension:
+            handleDimensionTool(snapped);
+            break;
         default:
             break;
     }
 }
 
 void SketchTool::onMouseMove(glm::vec2 pos) {
+    // Dimension mode has no drag/preview snapping of its own — just record the
+    // raw cursor for the ghost-label / hover-highlight overlay and bail before
+    // the snapping logic below (which doesn't apply to picking entities).
+    if (m_mode == SketchToolMode::Dimension) {
+        m_currentPos = pos;
+        return;
+    }
     // Trim uses the raw cursor for picking; snapping would pull the click toward
     // unrelated nearby targets and pick the wrong element.
     glm::vec2 newPos = (m_mode == SketchToolMode::Trim) ? pos : snap(pos);
@@ -267,6 +282,17 @@ void SketchTool::onConfirm() {
 }
 
 void SketchTool::onCancel() {
+    // Dimension mode: Escape backs out of an in-progress pick/placement
+    // first; only once nothing is pending does it fall through to exiting
+    // the tool (the app maps that by switching to Select).
+    if (m_mode == SketchToolMode::Dimension) {
+        if (m_dimPhase != DimPhase::PickFirst || m_dimReady) {
+            clearDimState();
+        } else {
+            setMode(SketchToolMode::Select);
+        }
+        return;
+    }
     // If only the first click of a line chain was made and we created its
     // anchor point fresh (no existing point was reused), drop that orphan so
     // a cancelled draw doesn't leave a stray yellow endpoint marker behind.
@@ -3110,6 +3136,196 @@ void SketchTool::undoLastStamp() {
     std::fprintf(stderr, "[Stamp] removed last placement (%zu elements, %zu stamp(s) left)\n",
                  ids.size(), m_stampStack.size() - 1);
     m_stampStack.pop_back();
+}
+
+// --- Dimension tool ---------------------------------------------------
+
+DimPick SketchTool::hitTestDimEntity(glm::vec2 pos) const {
+    DimPick out;
+    if (!m_sketch) return out;
+    int nearPt = findCoincidentPoint(pos, -1);
+    if (nearPt >= 0) {
+        // Text glyph geometry is not dimensionable.
+        const SketchPoint* p = m_sketch->getPoint(nearPt);
+        if (p && !p->fromText) { out = {DimEntityKind::Point, nearPt}; }
+        return out;
+    }
+    const float tol = std::max(m_gridStep * 0.5f, 0.5f) * snapScale();
+    // Lines (segment distance), skipping fromText — same math as handleSelectTool.
+    float bestD = 0.0f; int bestLine = -1;
+    for (const auto& l : m_sketch->getLines()) {
+        if (l.fromText) continue;
+        const SketchPoint* a = m_sketch->getPoint(l.startPointId);
+        const SketchPoint* b = m_sketch->getPoint(l.endPointId);
+        if (!a || !b) continue;
+        glm::vec2 ab = b->pos - a->pos;
+        float len2 = glm::dot(ab, ab);
+        if (len2 < 1e-12f) continue;
+        float t = glm::clamp(glm::dot(pos - a->pos, ab) / len2, 0.0f, 1.0f);
+        float d = glm::distance(a->pos + ab * t, pos);
+        if (d < tol && (bestLine < 0 || d < bestD)) { bestLine = l.id; bestD = d; }
+    }
+    if (bestLine >= 0) return {DimEntityKind::Line, bestLine};
+    // Circle then arc perimeters — same as handleSelectTool.
+    float bestCd = 0.0f; int bestCircle = -1;
+    for (const auto& c : m_sketch->getCircles()) {
+        const SketchPoint* ctr = m_sketch->getPoint(c.centerPointId);
+        if (!ctr) continue;
+        float d = std::abs(glm::distance(pos, ctr->pos) - static_cast<float>(c.radius));
+        if (d < tol && (bestCircle < 0 || d < bestCd)) { bestCircle = c.id; bestCd = d; }
+    }
+    if (bestCircle >= 0) return {DimEntityKind::Circle, bestCircle};
+    float bestAd = 0.0f; int bestArc = -1;
+    for (const auto& a : m_sketch->getArcs()) {
+        const SketchPoint* ctr = m_sketch->getPoint(a.centerPointId);
+        if (!ctr) continue;
+        float d = std::abs(glm::distance(pos, ctr->pos) - static_cast<float>(a.radius));
+        if (d < tol && (bestArc < 0 || d < bestAd)) { bestArc = a.id; bestAd = d; }
+    }
+    if (bestArc >= 0) return {DimEntityKind::Arc, bestArc};
+    return out;
+}
+
+void SketchTool::handleDimensionTool(glm::vec2 pos) {
+    if (!m_sketch) return;
+    m_currentPos = pos;
+    switch (m_dimPhase) {
+        case DimPhase::PickFirst: {
+            DimPick hit = hitTestDimEntity(pos);
+            if (hit.kind == DimEntityKind::None) return;
+            if (hit.kind == DimEntityKind::Circle || hit.kind == DimEntityKind::Arc) {
+                m_dimPending = resolveDimension(*m_sketch, hit, DimPick{});
+                if (m_dimPending.valid) { m_dimPickA = hit; m_dimPhase = DimPhase::PlaceLabel; }
+                return;
+            }
+            m_dimPickA = hit;
+            if (hit.kind == DimEntityKind::Line)
+                m_dimPending = resolveDimension(*m_sketch, hit, DimPick{}); // tentative length
+            else
+                m_dimPending = PendingDimension{}; // lone point: no dim yet
+            m_dimPhase = DimPhase::PickSecondOrPlace;
+            return;
+        }
+        case DimPhase::PickSecondOrPlace: {
+            DimPick hit = hitTestDimEntity(pos);
+            if (hit.kind != DimEntityKind::None) {
+                if (hit.kind == m_dimPickA.kind && hit.id == m_dimPickA.id) return; // same entity
+                PendingDimension pair = resolveDimension(*m_sketch, m_dimPickA, hit);
+                if (pair.valid) { m_dimPending = pair; m_dimPhase = DimPhase::PlaceLabel; }
+                return; // invalid combo: ignore the click, picks unchanged
+            }
+            // Empty space: places the tentative single-entity dim (line length).
+            if (m_dimPending.valid) { m_dimLabelPos = pos; m_dimReady = true; }
+            return; // lone point + empty space: no-op, pick stays pending
+        }
+        case DimPhase::PlaceLabel: {
+            m_dimLabelPos = pos;
+            m_dimReady = true;
+            return;
+        }
+    }
+}
+
+void SketchTool::clearDimState() {
+    m_dimPhase = DimPhase::PickFirst;
+    m_dimPickA = DimPick{};
+    m_dimPending = PendingDimension{};
+    m_dimReady = false;
+}
+
+PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPick b) {
+    PendingDimension out;
+    auto lineById = [&sk](int id) -> const SketchLine* {
+        for (const auto& l : sk.getLines()) if (l.id == id) return &l;
+        return nullptr;
+    };
+    auto lineEnds = [&sk, &lineById](int id, glm::vec2& s, glm::vec2& e) {
+        const SketchLine* l = lineById(id);
+        if (!l) return false;
+        const SketchPoint* sp = sk.getPoint(l->startPointId);
+        const SketchPoint* ep = sk.getPoint(l->endPointId);
+        if (!sp || !ep) return false;
+        s = sp->pos; e = ep->pos;
+        return true;
+    };
+    auto perpDist = [](glm::vec2 p, glm::vec2 s, glm::vec2 e) -> double {
+        glm::vec2 d = e - s;
+        float len = glm::length(d);
+        if (len < 1e-10f) return -1.0;
+        glm::vec2 r = p - s;
+        return std::abs(static_cast<double>(d.x) * r.y -
+                        static_cast<double>(d.y) * r.x) / len;
+    };
+
+    // Single-entity dims.
+    if (b.kind == DimEntityKind::None) {
+        if (a.kind == DimEntityKind::Circle) {
+            for (const auto& c : sk.getCircles())
+                if (c.id == a.id) { out = {ConstraintType::Radius, a.id, -1, c.radius, true}; break; }
+            return out;
+        }
+        if (a.kind == DimEntityKind::Arc) {
+            for (const auto& ar : sk.getArcs())
+                if (ar.id == a.id) { out = {ConstraintType::Radius, a.id, -1, ar.radius, true}; break; }
+            return out;
+        }
+        if (a.kind == DimEntityKind::Line) {
+            const SketchLine* l = lineById(a.id);
+            glm::vec2 s, e;
+            if (l && lineEnds(a.id, s, e))
+                out = {ConstraintType::Distance, l->startPointId, l->endPointId,
+                       static_cast<double>(glm::distance(s, e)), true};
+            return out;
+        }
+        return out; // lone point: invalid
+    }
+
+    // Normalize point-first for the mixed pair.
+    if (a.kind == DimEntityKind::Line && b.kind == DimEntityKind::Point) std::swap(a, b);
+
+    if (a.kind == DimEntityKind::Point && b.kind == DimEntityKind::Point) {
+        const SketchPoint* pa = sk.getPoint(a.id);
+        const SketchPoint* pb = sk.getPoint(b.id);
+        if (pa && pb)
+            out = {ConstraintType::Distance, a.id, b.id,
+                   static_cast<double>(glm::distance(pa->pos, pb->pos)), true};
+        return out;
+    }
+    if (a.kind == DimEntityKind::Point && b.kind == DimEntityKind::Line) {
+        const SketchPoint* p = sk.getPoint(a.id);
+        glm::vec2 s, e;
+        if (p && lineEnds(b.id, s, e)) {
+            double d = perpDist(p->pos, s, e);
+            if (d >= 0.0) out = {ConstraintType::DistancePointLine, a.id, b.id, d, true};
+        }
+        return out;
+    }
+    if (a.kind == DimEntityKind::Line && b.kind == DimEntityKind::Line) {
+        glm::vec2 as, ae, bs, be;
+        if (!lineEnds(a.id, as, ae) || !lineEnds(b.id, bs, be)) return out;
+        glm::vec2 da = ae - as, db = be - bs;
+        if (glm::length(da) < 1e-10f || glm::length(db) < 1e-10f) return out;
+        // Signed angle of B relative to A, wrapped to [-π, π] — same
+        // convention as the solver's Angle error term.
+        double ang = std::atan2(db.y, db.x) - std::atan2(da.y, da.x);
+        while (ang >  M_PI) ang -= 2.0 * M_PI;
+        while (ang < -M_PI) ang += 2.0 * M_PI;
+        // Parallel (or anti-parallel) within 1°: distance dim. The point is
+        // the SECOND line's start, measured to the FIRST line, so the first
+        // pick stays the reference for both branches.
+        const double kParallelTol = 1.0 * M_PI / 180.0;
+        double folded = std::min(std::abs(ang), M_PI - std::abs(ang));
+        if (folded <= kParallelTol) {
+            const SketchLine* lb = lineById(b.id);
+            double d = perpDist(bs, as, ae);
+            if (lb && d >= 0.0)
+                out = {ConstraintType::DistancePointLine, lb->startPointId, a.id, d, true};
+        } else {
+            out = {ConstraintType::Angle, a.id, b.id, ang, true};
+        }
+        return out;
+    }
+    return out; // circle/arc pairs and circle+point: out of scope
 }
 
 } // namespace materializr

--- a/src/modeling/SketchTool.cpp
+++ b/src/modeling/SketchTool.cpp
@@ -3296,6 +3296,14 @@ PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPi
         const SketchPoint* p = sk.getPoint(a.id);
         glm::vec2 s, e;
         if (p && lineEnds(b.id, s, e)) {
+            // Reject a point that IS an endpoint of the target line: the
+            // perpendicular distance is then 0 by construction, so a
+            // DistancePointLine constraint pinned at 0 has no direction to
+            // correct along — applyCorrection's ~value/2 nudge on the point
+            // and the line's endpoints cancels itself out every iteration
+            // and flings the other endpoint outward instead of converging.
+            const SketchLine* bl = lineById(b.id);
+            if (bl && (a.id == bl->startPointId || a.id == bl->endPointId)) return out;
             double d = perpDist(p->pos, s, e);
             if (d >= 0.0) out = {ConstraintType::DistancePointLine, a.id, b.id, d, true};
         }
@@ -3318,6 +3326,14 @@ PendingDimension SketchTool::resolveDimension(const Sketch& sk, DimPick a, DimPi
         double folded = std::min(std::abs(ang), M_PI - std::abs(ang));
         if (folded <= kParallelTol) {
             const SketchLine* lb = lineById(b.id);
+            const SketchLine* la = lineById(a.id);
+            // Same degenerate-pick hazard as the point+line branch above,
+            // reached a different way: chained near-collinear segments where
+            // the second line's start point IS one of the first line's own
+            // endpoints (a zero-distance pick in disguise).
+            if (lb && la &&
+                (lb->startPointId == la->startPointId || lb->startPointId == la->endPointId))
+                return out;
             double d = perpDist(bs, as, ae);
             if (lb && d >= 0.0)
                 out = {ConstraintType::DistancePointLine, lb->startPointId, a.id, d, true};

--- a/src/modeling/SketchTool.h
+++ b/src/modeling/SketchTool.h
@@ -335,6 +335,15 @@ public:
     glm::vec2 getDimLabelPos() const { return m_dimLabelPos; } // valid when dimReadyToCommit()
     bool dimReadyToCommit() const { return m_dimReady; }       // label placed; app commits + calls clearDimState()
     void clearDimState();                                       // back to PickFirst, pending invalidated
+    // One-shot reason the last Dimension click was refused, or nullptr. The
+    // tool used to just `return` on an unusable pick, so the click looked
+    // like it had simply missed — indistinguishable from a mis-aim. The app
+    // drains this each frame and toasts it. Reading clears it.
+    const char* consumeDimRejection() {
+        const char* r = m_dimRejectReason;
+        m_dimRejectReason = nullptr;
+        return r;
+    }
     DimPick dimHitTest(glm::vec2 pos) const { return hitTestDimEntity(pos); } // hover highlight for the viewport
     static PendingDimension resolveDimension(const Sketch& sk, DimPick a, DimPick b);
     // True when the two lines' directions are parallel or anti-parallel
@@ -523,6 +532,8 @@ private:
     PendingDimension m_dimPending;
     glm::vec2 m_dimLabelPos{0.0f};
     bool m_dimReady = false;
+    // Static string literal (never owns storage) — see consumeDimRejection.
+    const char* m_dimRejectReason = nullptr;
     DimPick hitTestDimEntity(glm::vec2 pos) const;
     void handleDimensionTool(glm::vec2 pos);
 };

--- a/src/modeling/SketchTool.h
+++ b/src/modeling/SketchTool.h
@@ -25,6 +25,17 @@ struct PendingDimension {
     bool valid = false;
 };
 
+// Shared "close enough to parallel/anti-parallel to dimension as a gap
+// rather than an angle" threshold (1 degree), in radians. Single source of
+// truth for SketchTool::resolveDimension's line-line branch AND
+// Application::applyPendingDimension's mirrored-DistancePointLine dedup
+// (which must not treat two genuinely angled lines as the same gap just
+// because their picked point/line ids happen to cross-reference each
+// other's endpoints — see SketchTool::linesParallelWithinDimTol). Written as
+// a literal rather than via M_PI/180 so this header doesn't need to pull in
+// <cmath> or the M_PI portability guard every other file including it uses.
+constexpr double kDimParallelTolRad = 0.017453292519943295; // 1.0 deg
+
 enum class DimPhase { PickFirst, PickSecondOrPlace, PlaceLabel };
 
 // One drawing-time alignment hint. Inferences are transient — they describe
@@ -326,6 +337,14 @@ public:
     void clearDimState();                                       // back to PickFirst, pending invalidated
     DimPick dimHitTest(glm::vec2 pos) const { return hitTestDimEntity(pos); } // hover highlight for the viewport
     static PendingDimension resolveDimension(const Sketch& sk, DimPick a, DimPick b);
+    // True when the two lines' directions are parallel or anti-parallel
+    // within kDimParallelTolRad — the same test resolveDimension's line-line
+    // branch uses to decide DistancePointLine vs Angle. Exposed standalone
+    // so callers outside resolveDimension (the mirrored-DistancePointLine
+    // dedup in Application::applyPendingDimension) can gate on the same
+    // definition of "parallel enough" instead of re-deriving it. False for
+    // a missing line id or a degenerate (zero-length) line.
+    static bool linesParallelWithinDimTol(const Sketch& sk, int lineIdA, int lineIdB);
 
 private:
     // Catch-range multipliers — >1 only at the Max inference tier, so Full and

--- a/src/modeling/SketchTool.h
+++ b/src/modeling/SketchTool.h
@@ -10,7 +10,22 @@
 
 namespace materializr {
 
-enum class SketchToolMode { None, Select, Line, Circle, Rectangle, Arc, Spline, Polygon, Trim, Text, Svg, Mirror };
+enum class SketchToolMode { None, Select, Line, Circle, Rectangle, Arc, Spline, Polygon, Trim, Text, Svg, Mirror, Dimension };
+
+enum class DimEntityKind { None, Point, Line, Circle, Arc };
+struct DimPick { DimEntityKind kind = DimEntityKind::None; int id = -1; };
+
+// A pick set resolved into the constraint it would create. measured is the
+// current geometry value: mm for distances, RADIUS in mm for Radius (UI
+// doubles it for display), SIGNED radians for Angle (line B rel. line A).
+struct PendingDimension {
+    ConstraintType type = ConstraintType::Distance;
+    int entityA = -1, entityB = -1;
+    double measured = 0.0;
+    bool valid = false;
+};
+
+enum class DimPhase { PickFirst, PickSecondOrPlace, PlaceLabel };
 
 // One drawing-time alignment hint. Inferences are transient — they describe
 // what the cursor IS aligned to right now, get drawn as coloured ghost lines /
@@ -302,6 +317,16 @@ public:
     // back out. Wrap the call in recordSketchMutation for one undo step. Line only.
     bool dropLineChainTail();
 
+    // --- Dimension tool (Onshape-style: pick 1-2 entities, place label) ---
+    DimPhase getDimPhase() const { return m_dimPhase; }
+    DimPick getDimPickA() const { return m_dimPickA; }
+    const PendingDimension& getPendingDimension() const { return m_dimPending; }
+    glm::vec2 getDimLabelPos() const { return m_dimLabelPos; } // valid when dimReadyToCommit()
+    bool dimReadyToCommit() const { return m_dimReady; }       // label placed; app commits + calls clearDimState()
+    void clearDimState();                                       // back to PickFirst, pending invalidated
+    DimPick dimHitTest(glm::vec2 pos) const { return hitTestDimEntity(pos); } // hover highlight for the viewport
+    static PendingDimension resolveDimension(const Sketch& sk, DimPick a, DimPick b);
+
 private:
     // Catch-range multipliers — >1 only at the Max inference tier, so Full and
     // below snap exactly as before on every device. See enum InferenceLevel.
@@ -472,6 +497,15 @@ private:
     // to its own starting position and the drag would feel sticky-broken).
     // Cleared in onMouseUp.
     std::set<int> m_snapExcludePoints;
+
+    // --- Dimension tool state ---
+    DimPhase m_dimPhase = DimPhase::PickFirst;
+    DimPick m_dimPickA;
+    PendingDimension m_dimPending;
+    glm::vec2 m_dimLabelPos{0.0f};
+    bool m_dimReady = false;
+    DimPick hitTestDimEntity(glm::vec2 pos) const;
+    void handleDimensionTool(glm::vec2 pos);
 };
 
 } // namespace materializr

--- a/src/plugins/SketchPlugin.cpp
+++ b/src/plugins/SketchPlugin.cpp
@@ -96,9 +96,23 @@ public:
     void renderOverlay(PluginContext& ctx) override {
         ImGui::SetCursorPos(ImVec2(10, 30));
         ImGui::PushStyleColor(ImGuiCol_Text, materializr::accentText());
-        ImGui::Text(materializr::touchMode()
-            ? "SKETCH MODE - Draw shapes. Finish Sketch applies, Exit Sketch discards."
-            : "SKETCH MODE - Draw shapes. Enter to finish, Escape to cancel.");
+        if (m_sketchTool->getMode() == SketchToolMode::Dimension) {
+            const char* msg = "DIMENSION - Click an entity to dimension.";
+            switch (m_sketchTool->getDimPhase()) {
+                case DimPhase::PickSecondOrPlace:
+                    msg = "DIMENSION - Click a second entity, or empty space to place.";
+                    break;
+                case DimPhase::PlaceLabel:
+                    msg = "DIMENSION - Click to place the label.";
+                    break;
+                default: break;
+            }
+            ImGui::Text("%s", msg);
+        } else {
+            ImGui::Text(materializr::touchMode()
+                ? "SKETCH MODE - Draw shapes. Finish Sketch applies, Exit Sketch discards."
+                : "SKETCH MODE - Draw shapes. Enter to finish, Escape to cancel.");
+        }
         ImGui::PopStyleColor();
 
         // Dimension input when placing

--- a/src/ui/HelpPanel.cpp
+++ b/src/ui/HelpPanel.cpp
@@ -47,9 +47,12 @@ void HelpPanel::render() {
         "Pick Sketch on XY/XZ/YZ from the Tools panel (or Sketch on Face after "
         "selecting one), then choose a tool: Line, Rectangle, Circle, Arc, "
         "Spline, Polygon, or Trim. Type a numeric dimension while placing to "
-        "lock the size. Switch to Select / Move to drag existing points and "
-        "lines — double-click empties to select the whole sketch, then use "
-        "Copy / Mirror / Rotate. Click Finish Sketch (or press Enter) to exit.");
+        "lock the size. Press D for the Dimension tool: click a line, circle, "
+        "two points, or two lines (parallel = distance, angled = angle), "
+        "click to place the label, then type the value. Switch to Select / "
+        "Move to drag existing points and lines — double-click empties to "
+        "select the whole sketch, then use Copy / Mirror / Rotate. Click "
+        "Finish Sketch (or press Enter) to exit.");
 
     section("Modelling from a sketch",
         "With a sketch region or face selected, click Extrude or Push/Pull. "

--- a/src/ui/PropertiesPanel.cpp
+++ b/src/ui/PropertiesPanel.cpp
@@ -708,18 +708,18 @@ void PropertiesPanel::renderSketchConstraintsPanel(int sketchId, bool& modified)
         for (const auto& c : sk->getConstraints()) {
             const char* tn = "?";
             switch (c.type) {
-                case ConstraintType::Coincident:    tn = "Coincident";    break;
-                case ConstraintType::Horizontal:    tn = "Horizontal";    break;
-                case ConstraintType::Vertical:      tn = "Vertical";      break;
-                case ConstraintType::Distance:      tn = "Distance";      break;
-                case ConstraintType::Radius:        tn = "Radius";        break;
-                case ConstraintType::Parallel:      tn = "Parallel";      break;
-                case ConstraintType::Perpendicular: tn = "Perpendicular"; break;
-                case ConstraintType::Fixed:         tn = "Fixed";         break;
-                case ConstraintType::Tangent:       tn = "Tangent";       break;
-                case ConstraintType::Equal:         tn = "Equal";         break;
-                case ConstraintType::Concentric:    tn = "Concentric";    break;
-                case ConstraintType::Angle:         tn = "Angle";         break;
+                case ConstraintType::Coincident:        tn = "Coincident";       break;
+                case ConstraintType::Horizontal:        tn = "Horizontal";       break;
+                case ConstraintType::Vertical:          tn = "Vertical";         break;
+                case ConstraintType::Distance:          tn = "Distance";         break;
+                case ConstraintType::Radius:            tn = "Radius";           break;
+                case ConstraintType::Parallel:          tn = "Parallel";         break;
+                case ConstraintType::Perpendicular:     tn = "Perpendicular";    break;
+                case ConstraintType::Fixed:             tn = "Fixed";            break;
+                case ConstraintType::Tangent:           tn = "Tangent";          break;
+                case ConstraintType::Equal:             tn = "Equal";            break;
+                case ConstraintType::Concentric:        tn = "Concentric";       break;
+                case ConstraintType::Angle:             tn = "Angle";            break;
                 case ConstraintType::DistancePointLine: tn = "Dist\xE2\x8A\xA5"; break;
             }
             std::fprintf(stderr, " %s=%.2f", tn, c.value);

--- a/src/ui/PropertiesPanel.cpp
+++ b/src/ui/PropertiesPanel.cpp
@@ -796,12 +796,14 @@ void PropertiesPanel::renderSketchConstraintsPanel(int sketchId, bool& modified)
         Constraint& c = cs[i];
         ImGui::PushID(static_cast<int>(c.id));
 
-        // Render dimensional ones (Distance, Radius/Diameter, Angle) inline.
-        // Non-dimensional ones get a single muted bullet — there's nothing to
-        // tune, but listing them confirms what's actually applied.
+        // Render dimensional ones (Distance, Radius/Diameter, Angle,
+        // point-to-line Distance) inline. Non-dimensional ones get a single
+        // muted bullet — there's nothing to tune, but listing them confirms
+        // what's actually applied.
         bool isDim = (c.type == ConstraintType::Distance ||
                       c.type == ConstraintType::Radius   ||
-                      c.type == ConstraintType::Angle);
+                      c.type == ConstraintType::Angle    ||
+                      c.type == ConstraintType::DistancePointLine);
         if (isDim) {
             ++anyDim;
             auto& edit = m_constraintEdits[c.id];
@@ -820,6 +822,7 @@ void PropertiesPanel::renderSketchConstraintsPanel(int sketchId, bool& modified)
             const char* label =
                 c.type == ConstraintType::Distance ? "Distance"
               : c.type == ConstraintType::Radius   ? "\xC3\x98 (diameter)"
+              : c.type == ConstraintType::DistancePointLine ? "Dist \xE2\x8A\xA5"
                                                    : "Angle";
             if (!edit.focused) {
                 std::snprintf(edit.buf, sizeof(edit.buf), "%.3f", shown);

--- a/src/ui/PropertiesPanel.cpp
+++ b/src/ui/PropertiesPanel.cpp
@@ -721,6 +721,7 @@ void PropertiesPanel::renderSketchConstraintsPanel(int sketchId, bool& modified)
                 case ConstraintType::Concentric:        tn = "Concentric";       break;
                 case ConstraintType::Angle:             tn = "Angle";            break;
                 case ConstraintType::DistancePointLine: tn = "Dist\xE2\x8A\xA5"; break;
+                case ConstraintType::CircleGap:         tn = "Gap";              break;
             }
             std::fprintf(stderr, " %s=%.2f", tn, c.value);
         }
@@ -760,6 +761,7 @@ void PropertiesPanel::renderSketchConstraintsPanel(int sketchId, bool& modified)
             case ConstraintType::Equal:         return "Equal length";
             case ConstraintType::Concentric:    return "Concentric";
             case ConstraintType::DistancePointLine: return "Dist\xE2\x8A\xA5";
+            case ConstraintType::CircleGap:     return "Gap";
             default:                            return "Constraint";
         }
     };
@@ -803,7 +805,8 @@ void PropertiesPanel::renderSketchConstraintsPanel(int sketchId, bool& modified)
         bool isDim = (c.type == ConstraintType::Distance ||
                       c.type == ConstraintType::Radius   ||
                       c.type == ConstraintType::Angle    ||
-                      c.type == ConstraintType::DistancePointLine);
+                      c.type == ConstraintType::DistancePointLine ||
+                      c.type == ConstraintType::CircleGap);
         if (isDim) {
             ++anyDim;
             auto& edit = m_constraintEdits[c.id];
@@ -823,6 +826,7 @@ void PropertiesPanel::renderSketchConstraintsPanel(int sketchId, bool& modified)
                 c.type == ConstraintType::Distance ? "Distance"
               : c.type == ConstraintType::Radius   ? "\xC3\x98 (diameter)"
               : c.type == ConstraintType::DistancePointLine ? "Dist \xE2\x8A\xA5"
+              : c.type == ConstraintType::CircleGap ? "Gap"
                                                    : "Angle";
             if (!edit.focused) {
                 std::snprintf(edit.buf, sizeof(edit.buf), "%.3f", shown);

--- a/src/ui/PropertiesPanel.cpp
+++ b/src/ui/PropertiesPanel.cpp
@@ -720,6 +720,7 @@ void PropertiesPanel::renderSketchConstraintsPanel(int sketchId, bool& modified)
                 case ConstraintType::Equal:         tn = "Equal";         break;
                 case ConstraintType::Concentric:    tn = "Concentric";    break;
                 case ConstraintType::Angle:         tn = "Angle";         break;
+                case ConstraintType::DistancePointLine: tn = "Dist\xE2\x8A\xA5"; break;
             }
             std::fprintf(stderr, " %s=%.2f", tn, c.value);
         }
@@ -758,6 +759,7 @@ void PropertiesPanel::renderSketchConstraintsPanel(int sketchId, bool& modified)
             case ConstraintType::Tangent:       return "Tangent";
             case ConstraintType::Equal:         return "Equal length";
             case ConstraintType::Concentric:    return "Concentric";
+            case ConstraintType::DistancePointLine: return "Dist\xE2\x8A\xA5";
             default:                            return "Constraint";
         }
     };

--- a/src/ui/Toolbar.cpp
+++ b/src/ui/Toolbar.cpp
@@ -123,7 +123,7 @@ std::vector<Toolbar::RailTool> Toolbar::railTools() const {
     };
 
     if (m_sketchMode) {
-        // SketchToolMode ints per setActiveSketchMode(): 1=Select … 8=Trim.
+        // SketchToolMode ints per setActiveSketchMode(): 1=Select … 8=Trim, 12=Dimension.
         add(MZ_ICON_SELECT,  "Select",  ToolAction::SelectSketch, m_activeSketchMode == 1,
             "Pick sketch elements (points, lines, regions). Drag a selection to move it.");
         add(MZ_ICON_LINE,    "Line",    ToolAction::Line,         m_activeSketchMode == 2,
@@ -159,6 +159,9 @@ std::vector<Toolbar::RailTool> Toolbar::railTools() const {
             "width in the popup, tap to place.");
         add(MZ_ICON_TRIM,    "Trim",    ToolAction::Trim,         m_activeSketchMode == 8,
             "Trim a sketch segment at its nearest intersections.");
+        add(MZ_ICON_MEASURE, "Dimension", ToolAction::SketchDimension,
+            m_activeSketchMode == 12,
+            "Dimension: tap entities, tap to place the label, type the value.");
         // Sketch-element transforms — mirror the classic sketch toolbar so all
         // three layouts behave identically. Like classic, they're always here
         // in a sketch and simply no-op if nothing is selected. (The rail
@@ -648,6 +651,9 @@ ToolAction Toolbar::renderSketchTools() {
         "extrude a logo or engrave it onto a face.");
     if (skBtn("Trim",      8))     action = ToolAction::Trim;
     tip("Trim a sketch segment at the nearest intersections.");
+    if (skBtn("Dimension", 12))    action = ToolAction::SketchDimension;
+    tip("Dimension tool (D): click a line, circle, point pair, or two lines, "
+        "place the label, then type the value.");
 
     // Transforms operate on the current sketch-element selection (Select tool +
     // click/Ctrl+click on points and lines). No-op if nothing is selected.

--- a/src/ui/Toolbar.h
+++ b/src/ui/Toolbar.h
@@ -15,7 +15,7 @@ enum class ToolAction {
     // Sketch tools (still dispatched via ToolAction — tightly coupled to viewport)
     StartSketch, StartSketchXY, StartSketchXZ, StartSketchYZ,
     SketchOnFace, SelectSketch, Line, Circle, Rectangle, Arc, Spline, Polygon, Trim, SketchText,
-    SketchSvg,
+    SketchSvg, SketchDimension,
     FinishSketch, ExitSketchDiscard, EditSketch, ExtrudeSketch, SubtractSketch, PushPull, MoveFace, LookAtSketch,
     SketchCopy, SketchMirror, SketchLinearPattern, SketchRadialPattern,
     // Cycle the drawing-inference level Full → Reduced → Off.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(materializr_core STATIC
     ${CMAKE_SOURCE_DIR}/src/modeling/BatchTransformOp.cpp
     ${CMAKE_SOURCE_DIR}/src/modeling/PushPullOp.cpp
     ${CMAKE_SOURCE_DIR}/src/modeling/Sketch.cpp
+    ${CMAKE_SOURCE_DIR}/src/modeling/SketchTool.cpp
     ${CMAKE_SOURCE_DIR}/src/modeling/SketchEditOp.cpp
     ${CMAKE_SOURCE_DIR}/src/modeling/DuplicateSketchOp.cpp
     ${CMAKE_SOURCE_DIR}/src/modeling/MoveHoleOp.cpp
@@ -467,7 +468,14 @@ add_test(NAME test_brepio_dos COMMAND test_brepio_dos)
 
 # test_sketch_dimension — DistancePointLine solver, dimension pair resolution,
 # and K-line label-offset persistence (Onshape-style dimension tool).
-add_executable(test_sketch_dimension test_sketch_dimension.cpp)
-target_link_libraries(test_sketch_dimension PRIVATE materializr_core gtest gtest_main)
+# Pulls in SketchTool.h/.cpp (the Dimension pick state machine), which in turn
+# needs TextSketchOp.cpp (handleTextTool) and SvgImport.cpp (handleSvgTool) —
+# neither is in materializr_core, and SvgImport renders SVG text to outline
+# wires via Font_* (TKV3d/TKService), same as test_svg_roundtrip above.
+add_executable(test_sketch_dimension test_sketch_dimension.cpp
+    ${CMAKE_SOURCE_DIR}/src/modeling/TextSketchOp.cpp
+    ${CMAKE_SOURCE_DIR}/src/modeling/SvgImport.cpp)
+target_link_libraries(test_sketch_dimension PRIVATE materializr_core gtest gtest_main
+    TKV3d TKService)
 add_test(NAME test_sketch_dimension COMMAND test_sketch_dimension)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -205,6 +205,14 @@ add_executable(test_recovery test_recovery.cpp)
 target_link_libraries(test_recovery PRIVATE materializr_core gtest gtest_main)
 add_test(NAME test_recovery COMMAND test_recovery)
 
+# test_recovery_popup_turntaking — headless dear imgui popup-stack regression
+# for the "Recover Sketch?" modal rendering empty/stuck when it collides with
+# another raw-every-frame OpenPopup (the launch update-check popup). Pure
+# ImGui mechanics — links imgui_lib directly, no OCCT/materializr_core needed.
+add_executable(test_recovery_popup_turntaking test_recovery_popup_turntaking.cpp)
+target_link_libraries(test_recovery_popup_turntaking PRIVATE imgui_lib gtest gtest_main)
+add_test(NAME test_recovery_popup_turntaking COMMAND test_recovery_popup_turntaking)
+
 # Exchange formats: BREP round-trip, OBJ/DXF/3MF structural checks
 add_executable(test_exchange_io test_exchange_io.cpp)
 target_link_libraries(test_exchange_io PRIVATE materializr_core gtest gtest_main)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -464,3 +464,10 @@ add_test(NAME test_audit_hardening COMMAND test_audit_hardening)
 add_executable(test_brepio_dos test_brepio_dos.cpp)
 target_link_libraries(test_brepio_dos PRIVATE materializr_core gtest gtest_main)
 add_test(NAME test_brepio_dos COMMAND test_brepio_dos)
+
+# test_sketch_dimension — DistancePointLine solver, dimension pair resolution,
+# and K-line label-offset persistence (Onshape-style dimension tool).
+add_executable(test_sketch_dimension test_sketch_dimension.cpp)
+target_link_libraries(test_sketch_dimension PRIVATE materializr_core gtest gtest_main)
+add_test(NAME test_sketch_dimension COMMAND test_sketch_dimension)
+

--- a/tests/test_recovery_popup_turntaking.cpp
+++ b/tests/test_recovery_popup_turntaking.cpp
@@ -1,0 +1,216 @@
+// Regression test for the "Recover Sketch?" modal rendering as an empty,
+// permanently-stuck 28x45 window that still blocks all input (issue: launch
+// with a sketch draft + an autosave present).
+//
+// Root cause: Application::renderSketchRecoveryPrompt() / renderProjectRecoveryPrompt()
+// call ImGui::OpenPopup() UNCONDITIONALLY every frame (src/app/Application.cpp,
+// renderSketchRecoveryPrompt ~5344, renderProjectRecoveryPrompt ~5470) — a
+// pattern the codebase's own comment there already recognized as dangerous:
+// "opening a second popup at the same stack level ... makes the two close
+// each other every frame ... neither ever draws" — and gates against it
+// w.r.t. the Welcome screen and each other. Application_Dialogs.cpp's
+// renderUpdatePopup() (~line 662) ALSO calls OpenPopup() unconditionally
+// every frame while m_showUpdatePopup is true, but had NO gate against the
+// recovery prompts. m_showUpdatePopup flips true asynchronously (the launch
+// update check runs on a background thread and can resolve at any frame,
+// including while a recovery prompt is up), so the two raw-every-frame
+// OpenPopup calls contend for the same popup-stack level (0) and steal it
+// from each other every single frame — via dear imgui's
+// "OpenPopupEx / re-open" path (imgui.cpp), which treats every such steal as
+// a fresh popup activation, resetting Size/ContentSize to 0 and hiding the
+// window for exactly one frame (HiddenFramesCannotSkipItems=1) EVERY frame,
+// forever. The window is never NOT hidden long enough to compute a real
+// size, so it's permanently drawn nowhere at a degenerate floor size, while
+// still occupying the modal popup stack (blocking all other input) — exactly
+// the reported symptom.
+//
+// This test exercises the real dear imgui popup-stack mechanics headlessly
+// (CreateContext / NewFrame / Begin / End, no window/GL backend) against two
+// harness functions written to mirror the production call sites: `popupA()`
+// (renderUpdatePopup) and `popupB()` (renderSketchRecoveryPrompt). It proves
+// (1) the anti-pattern — no gate — deadlocks both popups permanently hidden
+// at a degenerate size, and (2) the fix — popupA gates on popupB's pending
+// state, exactly like Application_Dialogs.cpp now does — lets popupB render
+// and stabilize at a real size, and popupA opens cleanly once popupB clears.
+
+#define IMGUI_DEFINE_MATH_OPERATORS
+#include <imgui.h>
+#include <imgui_internal.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// A fresh ImGui context per test so the two TESTs below don't share popup
+// stack / window state.
+class ImGuiHeadlessTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        IMGUI_CHECKVERSION();
+        ctx_ = ImGui::CreateContext();
+        ImGui::SetCurrentContext(ctx_);
+        ImGuiIO& io = ImGui::GetIO();
+        io.DisplaySize = ImVec2(1280, 800);
+        io.IniFilename = nullptr; // no disk I/O from this test
+        unsigned char* pixels; int w, h;
+        io.Fonts->GetTexDataAsAlpha8(&pixels, &w, &h); // builds the default font
+        io.Fonts->SetTexID((ImTextureID)(intptr_t)1);
+    }
+    void TearDown() override {
+        ImGui::DestroyContext(ctx_);
+        ctx_ = nullptr;
+    }
+    void NewFrame() {
+        ImGui::GetIO().DeltaTime = 1.0f / 60.0f;
+        ImGui::NewFrame();
+    }
+    void EndFrame() { ImGui::Render(); }
+
+    ImGuiContext* ctx_ = nullptr;
+};
+
+// Mirrors Application_Dialogs.cpp::renderUpdatePopup(): a modal that opens
+// unconditionally, every frame, while `active` is true.
+void popupA_updatePopup(bool active, bool gateOnB, bool bPending) {
+    if (!active) return;
+    if (gateOnB && bPending) return; // the fix
+    ImGui::OpenPopup("Check for Updates");
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(400, 220), ImGuiCond_Appearing);
+    if (ImGui::BeginPopupModal("Check for Updates", nullptr, ImGuiWindowFlags_NoResize)) {
+        ImGui::Text("Current version: 0.0.0");
+        if (ImGui::Button("Close")) ImGui::CloseCurrentPopup();
+        ImGui::EndPopup();
+    }
+}
+
+// Mirrors Application.cpp::renderSketchRecoveryPrompt(): a modal that opens
+// unconditionally, every frame, while `*pending` is true.
+bool popupB_sketchRecovery(bool* pending) {
+    if (!*pending) return false;
+    ImGui::OpenPopup("Recover Sketch?");
+    ImVec2 c = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(c, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    bool contentRan = false;
+    if (ImGui::BeginPopupModal("Recover Sketch?", nullptr,
+                               ImGuiWindowFlags_AlwaysAutoResize |
+                               ImGuiWindowFlags_NoSavedSettings)) {
+        contentRan = true;
+        ImGui::TextUnformatted("An unfinished sketch from your last session was found.");
+        ImGui::TextDisabled("It wasn't committed before the app closed.");
+        if (ImGui::Button("Restore it")) { *pending = false; ImGui::CloseCurrentPopup(); }
+        ImGui::SameLine();
+        if (ImGui::Button("Discard")) { *pending = false; ImGui::CloseCurrentPopup(); }
+        ImGui::EndPopup();
+    }
+    return contentRan;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// (1) The anti-pattern: popupA has NO gate against popupB. Once popupA
+// activates mid-flight (simulating the async update check resolving while
+// the sketch-recovery prompt is up), the two raw-every-frame OpenPopup calls
+// steal the popup-stack level from each other every frame. Assert this
+// really does deadlock — both windows permanently Hidden at a degenerate
+// size — so the mechanism behind the reported bug is pinned, not assumed.
+// ---------------------------------------------------------------------------
+TEST_F(ImGuiHeadlessTest, UngatedCompetingPopupsDeadlockHiddenForever) {
+    bool sketchPending = true;
+    bool updateActive = false;
+
+    // Frames 1-2: only popupB is active — it opens and stabilizes normally.
+    for (int frame = 1; frame <= 2; ++frame) {
+        NewFrame();
+        popupA_updatePopup(updateActive, /*gateOnB=*/false, sketchPending);
+        popupB_sketchRecovery(&sketchPending);
+        EndFrame();
+    }
+    {
+        ImGuiWindow* b = ImGui::FindWindowByName("Recover Sketch?");
+        ASSERT_NE(b, nullptr);
+        EXPECT_FALSE(b->Hidden);
+        EXPECT_GT(b->Size.x, 100.0f) << "sketch prompt should have a real, laid-out width";
+    }
+
+    // Frame 3: the async update check resolves — popupA activates. From here
+    // on both call OpenPopup() every frame with no turn-taking.
+    updateActive = true;
+    for (int frame = 3; frame <= 15; ++frame) {
+        NewFrame();
+        popupA_updatePopup(updateActive, /*gateOnB=*/false, sketchPending);
+        popupB_sketchRecovery(&sketchPending);
+        EndFrame();
+    }
+
+    ImGuiWindow* a = ImGui::FindWindowByName("Check for Updates");
+    ImGuiWindow* b = ImGui::FindWindowByName("Recover Sketch?");
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+
+    // This is the reported bug, reproduced: both windows are permanently
+    // Hidden (never actually drawn/rendered) and pinned at the degenerate
+    // "just reset, nothing measured yet" floor size — not the real ~478x92
+    // content size — even though m_pendingSketchRecovery is STILL true (the
+    // user can never see or click the buttons that would clear it).
+    EXPECT_TRUE(sketchPending) << "prompt can never be dismissed — its buttons never render";
+    EXPECT_TRUE(a->Hidden);
+    EXPECT_TRUE(b->Hidden);
+    EXPECT_LT(b->Size.x, 50.0f) << "stuck at the degenerate floor size, never the real content size";
+}
+
+// ---------------------------------------------------------------------------
+// (2) The fix: popupA gates on popupB's pending flag, mirroring the turn-
+// taking gate added to Application_Dialogs.cpp::renderUpdatePopup(). Assert
+// popupB renders and stays stable regardless of when popupA's trigger fires,
+// and popupA itself opens cleanly and stabilizes once popupB clears.
+// ---------------------------------------------------------------------------
+TEST_F(ImGuiHeadlessTest, GatedUpdatePopupLetsSketchRecoveryRenderAndStabilize) {
+    bool sketchPending = true;
+    bool updateActive = false;
+
+    for (int frame = 1; frame <= 2; ++frame) {
+        NewFrame();
+        popupA_updatePopup(updateActive, /*gateOnB=*/true, sketchPending);
+        popupB_sketchRecovery(&sketchPending);
+        EndFrame();
+    }
+
+    // The async update check "resolves" mid-flight, same as the deadlock test.
+    updateActive = true;
+    float stableWidth = -1.0f;
+    for (int frame = 3; frame <= 8; ++frame) {
+        NewFrame();
+        popupA_updatePopup(updateActive, /*gateOnB=*/true, sketchPending);
+        popupB_sketchRecovery(&sketchPending);
+        EndFrame();
+
+        ImGuiWindow* b = ImGui::FindWindowByName("Recover Sketch?");
+        ASSERT_NE(b, nullptr);
+        EXPECT_FALSE(b->Hidden) << "frame " << frame;
+        if (frame == 4) stableWidth = b->Size.x; // one settle frame after the trigger
+    }
+    ASSERT_GT(stableWidth, 100.0f);
+    // "Check for Updates" must not exist yet — it's still gated off.
+    EXPECT_EQ(ImGui::FindWindowByName("Check for Updates"), nullptr);
+
+    // User dismisses the sketch prompt (mirrors clicking "Discard", which
+    // this harness can't do via a synthetic mouse click — set the flag the
+    // button's handler would have set instead).
+    sketchPending = false;
+
+    // Now popupA should open cleanly (one hidden settle frame) and stabilize.
+    for (int frame = 1; frame <= 3; ++frame) {
+        NewFrame();
+        popupA_updatePopup(updateActive, /*gateOnB=*/true, sketchPending);
+        popupB_sketchRecovery(&sketchPending);
+        EndFrame();
+    }
+    ImGuiWindow* a = ImGui::FindWindowByName("Check for Updates");
+    ASSERT_NE(a, nullptr);
+    EXPECT_FALSE(a->Hidden);
+    EXPECT_FLOAT_EQ(a->Size.x, 400.0f);
+    EXPECT_FLOAT_EQ(a->Size.y, 220.0f);
+}

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -80,6 +80,38 @@ TEST(DistancePointLine, MissingEntitiesAreInert) {
     EXPECT_NEAR(sk.getPoint(p)->pos.y, 1.0f, 1e-6);
 }
 
+TEST(DistancePointLine, DegeneratePointOnOwnLineStaysBounded) {
+    // entityA == the line's own start point is a degenerate constraint that
+    // resolveDimension now refuses to produce (see the DimensionResolve
+    // rejection tests below), but a constraint can still reach the solver
+    // another way — an older project file, or direct injection as here.
+    // Before the applyCorrection identity guard, this residual-0 constraint
+    // fed a non-zero ~value/2 correction into BOTH the point and the line's
+    // endpoints every iteration, which cancelled out for the point (moved
+    // back to where it started) but not for the far endpoint, which got
+    // flung outward without bound. The guard should leave everything inert.
+    Sketch sk;
+    int a = sk.addPoint({0.0f, 0.0f});
+    int b = sk.addPoint({10.0f, 0.0f});
+    int ln = sk.addLine(a, b);
+    glm::vec2 origA = sk.getPoint(a)->pos;
+    glm::vec2 origB = sk.getPoint(b)->pos;
+    const double value = 5.0;
+    sk.addConstraint(makeDPL(a, ln, value));
+
+    SketchSolver solver;
+    solver.solve(sk, 200, 1e-4); // must not crash, NaN, or diverge
+
+    for (const auto& pt : sk.getPoints()) {
+        EXPECT_TRUE(std::isfinite(pt.pos.x));
+        EXPECT_TRUE(std::isfinite(pt.pos.y));
+    }
+    double dispA = glm::length(sk.getPoint(a)->pos - origA);
+    double dispB = glm::length(sk.getPoint(b)->pos - origB);
+    EXPECT_LT(dispA, 10.0 * value);
+    EXPECT_LT(dispB, 10.0 * value);
+}
+
 #include "core/Document.h"
 #include "io/ProjectIO.h"
 
@@ -320,4 +352,69 @@ TEST(DimensionResolve, InvalidCombosAreInvalid) {
     // dangling id
     auto r3 = SketchTool::resolveDimension(sk, pick(DimEntityKind::Line, 9999), DimPick{});
     EXPECT_FALSE(r3.valid);
+}
+
+// Degenerate pick: a point that IS an endpoint of the target line measures a
+// perpendicular distance of 0 by construction, which — if resolveDimension
+// let it through — would create a DistancePointLine constraint whose
+// applyCorrection has nothing to correct along (see the solver-side
+// DegeneratePointOnOwnLineStaysBounded test above). Both reachable paths
+// (direct point+line pick, and the line-line parallel branch whose derived
+// point is the second line's own start) must reject instead.
+TEST(DimensionResolve, RejectsPointOnOwnLineEndpoint) {
+    DimFixture f(30.0f);
+    // pA is the START point of lnAB itself.
+    auto r1 = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Point, f.pA),
+                                           pick(DimEntityKind::Line, f.lnAB));
+    EXPECT_FALSE(r1.valid);
+    // pB is the END point of lnAB — same rejection, opposite endpoint and
+    // opposite pick order (line first, point second).
+    auto r2 = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Line, f.lnAB),
+                                           pick(DimEntityKind::Point, f.pB));
+    EXPECT_FALSE(r2.valid);
+    // Sanity: a genuinely off-line point through the same branch still
+    // resolves normally (guards against an over-broad rejection).
+    auto r3 = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Point, f.pFree),
+                                           pick(DimEntityKind::Line, f.lnAB));
+    EXPECT_TRUE(r3.valid);
+}
+
+TEST(DimensionResolve, RejectsChainedCollinearLineLineSharedVertex) {
+    Sketch sk;
+    int pA = sk.addPoint({0.0f, 0.0f});
+    int pB = sk.addPoint({10.0f, 0.0f});
+    int lnAB = sk.addLine(pA, pB);
+    // Second line starts exactly AT pB (a chained segment sharing the
+    // vertex, e.g. drawn as a continuing line chain) and is nearly
+    // collinear with AB (~0.29 deg) — inside the parallel threshold. The
+    // parallel branch's derived point (second line's start == pB) is an
+    // endpoint of the FIRST line, so this must reject just like the direct
+    // point+line pick above.
+    int pF = sk.addPoint({20.0f, 0.05f});
+    int lnBF = sk.addLine(pB, pF);
+    auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Line, lnAB),
+                                          pick(DimEntityKind::Line, lnBF));
+    EXPECT_FALSE(r.valid);
+}
+
+// TEST GAP 9: pin the parallel/angle threshold's boundary behaviour. The
+// tolerance check in resolveDimension is `folded <= kParallelTol` with
+// kParallelTol == 1.0 degree in double precision. DimFixture builds its
+// rotated line through a FLOAT pi/180 conversion and float sin/cos, so the
+// angle it actually produces for deg=1.0 is not bit-identical to the double
+// 1-degree tolerance — empirically (see scratch probe) it lands a hair
+// UNDER the tolerance, so <= keeps 1.0 deg on the parallel
+// (DistancePointLine) side. 1.5 deg is unambiguously past the threshold.
+TEST(DimensionResolve, ParallelThresholdBoundary) {
+    DimFixture at1(1.0f);
+    auto atThreshold = SketchTool::resolveDimension(
+        at1.sk, pick(DimEntityKind::Line, at1.lnAB), pick(DimEntityKind::Line, at1.lnCD));
+    ASSERT_TRUE(atThreshold.valid);
+    EXPECT_EQ(atThreshold.type, ConstraintType::DistancePointLine);
+
+    DimFixture at15(1.5f);
+    auto pastThreshold = SketchTool::resolveDimension(
+        at15.sk, pick(DimEntityKind::Line, at15.lnAB), pick(DimEntityKind::Line, at15.lnCD));
+    ASSERT_TRUE(pastThreshold.valid);
+    EXPECT_EQ(pastThreshold.type, ConstraintType::Angle);
 }

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -164,6 +164,150 @@ TEST(CircleGap, SolverDrivesRimGapToTarget) {
     EXPECT_NEAR(rB, 3.0, 1e-9);
 }
 
+TEST(ReferenceDimension, DoesNotDriveGeometry) {
+    // A reference dimension measures without moving anything: the solver skips
+    // it entirely. Same setup as SolverDrivesCircleRadius, isDriving cleared.
+    Sketch sk;
+    int ctr = sk.addPoint({0.0f, 0.0f});
+    int ci  = sk.addCircle(ctr, 5.0);
+    Constraint c{};
+    c.type = ConstraintType::Radius;
+    c.entityA = ci;
+    c.value = 8.0;
+    c.isDriving = false;
+    sk.addConstraint(c);
+
+    SketchSolver solver;
+    EXPECT_TRUE(solver.solve(sk, 500, 1e-4));
+    double r = 0.0;
+    for (const auto& x : sk.getCircles()) if (x.id == ci) r = x.radius;
+    EXPECT_NEAR(r, 5.0, 1e-9) << "reference dimension moved the geometry";
+}
+
+TEST(ReferenceDimension, RemeasuresItselfAfterSolve) {
+    // The stored value follows the geometry, so the label always reports what
+    // is actually there — value 999 is overwritten by the real radius.
+    Sketch sk;
+    int ctr = sk.addPoint({0.0f, 0.0f});
+    int ci  = sk.addCircle(ctr, 5.0);
+    Constraint c{};
+    c.type = ConstraintType::Radius;
+    c.entityA = ci;
+    c.value = 999.0;
+    c.isDriving = false;
+    int id = sk.addConstraint(c);
+
+    SketchSolver solver;
+    solver.solve(sk, 500, 1e-4);
+    double stored = 0.0;
+    for (const auto& x : sk.getConstraints()) if (x.id == id) stored = x.value;
+    EXPECT_NEAR(stored, 5.0, 1e-6) << "reference value did not re-measure";
+}
+
+TEST(ReferenceDimension, CostsNoDegreeOfFreedom) {
+    // Annotating a sketch must not push it toward Fully/Over-constrained.
+    Sketch sk;
+    int a = sk.addPoint({0.0f, 0.0f});
+    int b = sk.addPoint({10.0f, 0.0f});
+    sk.addLine(a, b);
+
+    SketchSolver solver;
+    solver.solve(sk, 200, 1e-4);
+    int dofBefore = solver.degreesOfFreedom();
+
+    Constraint c{};
+    c.type = ConstraintType::Distance;
+    c.entityA = a;
+    c.entityB = b;
+    c.value = 10.0;
+    c.isDriving = false;
+    sk.addConstraint(c);
+    solver.solve(sk, 200, 1e-4);
+    EXPECT_EQ(solver.degreesOfFreedom(), dofBefore)
+        << "reference dimension consumed a DOF";
+}
+
+TEST(ReferenceDimension, DrivingStillConsumesDegreeOfFreedom) {
+    // Control for the test above — the same constraint, driving, does count.
+    Sketch sk;
+    int a = sk.addPoint({0.0f, 0.0f});
+    int b = sk.addPoint({10.0f, 0.0f});
+    sk.addLine(a, b);
+
+    SketchSolver solver;
+    solver.solve(sk, 200, 1e-4);
+    int dofBefore = solver.degreesOfFreedom();
+
+    Constraint c{};
+    c.type = ConstraintType::Distance;
+    c.entityA = a;
+    c.entityB = b;
+    c.value = 10.0;
+    c.isDriving = true;
+    sk.addConstraint(c);
+    solver.solve(sk, 200, 1e-4);
+    EXPECT_EQ(solver.degreesOfFreedom(), dofBefore - 1);
+}
+
+TEST(ReferenceDimension, DefaultsToDrivingForBackCompat) {
+    // Every constraint ever written before isDriving existed — and every
+    // geometric type — must keep driving. The struct default guarantees it.
+    Constraint c{};
+    EXPECT_TRUE(c.isDriving);
+    EXPECT_FALSE(materializr::constraintSupportsReference(ConstraintType::Horizontal));
+    EXPECT_TRUE(materializr::constraintSupportsReference(ConstraintType::Distance));
+    EXPECT_TRUE(materializr::constraintSupportsReference(ConstraintType::Radius));
+}
+
+TEST(RadiusConstraint, SolverDrivesCircleRadius) {
+    // Control for the arc case below: Radius on a CIRCLE does drive geometry.
+    Sketch sk;
+    int ctr = sk.addPoint({0.0f, 0.0f});
+    int ci  = sk.addCircle(ctr, 5.0);
+    Constraint c{};
+    c.type = ConstraintType::Radius;
+    c.entityA = ci;
+    c.value = 8.0;
+    sk.addConstraint(c);
+
+    SketchSolver solver;
+    EXPECT_TRUE(solver.solve(sk, 500, 1e-4));
+    double r = 0.0;
+    for (const auto& x : sk.getCircles()) if (x.id == ci) r = x.radius;
+    EXPECT_NEAR(r, 8.0, 1e-2);
+}
+
+TEST(RadiusConstraint, SolverDrivesArcRadius) {
+    // The Dimension tool creates ConstraintType::Radius for an ARC pick
+    // (SketchTool::resolveDimension, the DimEntityKind::Arc branch), so the
+    // solver must drive an arc's radius exactly as it drives a circle's.
+    // computeError()'s Radius branch only scans getCircles(), so an arc id
+    // yields error 0.0 → "already satisfied" → applyCorrection's arc branch is
+    // never reached and the radius never moves, while solve() still returns
+    // true and the label renders the TYPED value (Application_Viewport.cpp
+    // renders c.value * 2.0, not the measured radius) — a dimension that
+    // disagrees with its own geometry.
+    Sketch sk;
+    int ctr   = sk.addPoint({0.0f, 0.0f});
+    int start = sk.addPoint({5.0f, 0.0f});
+    int end   = sk.addPoint({0.0f, 5.0f});
+    int ar    = sk.addArc(ctr, start, end, 5.0);
+    Constraint c{};
+    c.type = ConstraintType::Radius;
+    c.entityA = ar;
+    c.value = 8.0;
+    sk.addConstraint(c);
+
+    SketchSolver solver;
+    bool converged = solver.solve(sk, 500, 1e-4);
+    double r = 0.0;
+    for (const auto& x : sk.getArcs()) if (x.id == ar) r = x.radius;
+    // The bug: converged == true while r is still 5.0.
+    EXPECT_NEAR(r, 8.0, 1e-2) << "arc radius not driven (solve returned "
+                              << (converged ? "true" : "false")
+                              << ") — label would read 16.00 mm on a 10.00 mm arc";
+}
+
 TEST(DistancePointLine, DegenerateLineDoesNotNaN) {
     Sketch sk;
     int a = sk.addPoint({2.0f, 2.0f});
@@ -305,6 +449,94 @@ TEST(DimensionPersistence, LegacySixFieldKLineDefaultsOffsetsToZero) {
     EXPECT_DOUBLE_EQ(sk.getConstraints()[0].value, 4.0);
     EXPECT_DOUBLE_EQ(sk.getConstraints()[0].labelOffX, 0.0);
     EXPECT_DOUBLE_EQ(sk.getConstraints()[0].labelOffY, 0.0);
+}
+
+TEST(DimensionPersistence, LegacyKLinesDefaultToDriving) {
+    // Neither a 6-field (pre-offset) nor an 8-field (pre-isDriving) K line
+    // carries the driving flag. Both must load as DRIVING, or every
+    // constraint in every existing project would silently stop enforcing.
+    std::string body =
+        "PLANE 0 0 0 0 0 1 1 0 0 0 1 0\n"
+        "POINT_COUNT 2\n"
+        "P 1 0 0 0 0\n"
+        "P 2 4 0 0 0\n"
+        "LINE_COUNT 1\n"
+        "L 3 1 2 0 0\n"
+        "CIRCLE_COUNT 0\n"
+        "ARC_COUNT 0\n"
+        "SPLINE_COUNT 0\n"
+        "POLYGON_COUNT 0\n"
+        "CONSTRAINT_COUNT 2\n"
+        "K 4 3 1 2 4 0\n"              // 6 fields (legacy)
+        "K 5 3 1 2 4 0 1.5 2.5\n"      // 8 fields (pre-isDriving)
+        "SKETCH_END\n";
+    std::istringstream is(body);
+    Sketch sk;
+    materializr::ProjectIO::parseSketchBody(is, sk, "SKETCH_END");
+    ASSERT_EQ(sk.getConstraints().size(), 2u);
+    for (const auto& c : sk.getConstraints())
+        EXPECT_TRUE(c.isDriving) << "legacy constraint id " << c.id
+                                 << " loaded as non-driving";
+}
+
+TEST(DimensionPersistence, IsDrivingRoundTrips) {
+    std::string body =
+        "PLANE 0 0 0 0 0 1 1 0 0 0 1 0\n"
+        "POINT_COUNT 2\n"
+        "P 1 0 0 0 0\n"
+        "P 2 4 0 0 0\n"
+        "LINE_COUNT 1\n"
+        "L 3 1 2 0 0\n"
+        "CIRCLE_COUNT 0\n"
+        "ARC_COUNT 0\n"
+        "SPLINE_COUNT 0\n"
+        "POLYGON_COUNT 0\n"
+        "CONSTRAINT_COUNT 2\n"
+        "K 4 3 1 2 4 0 0 0 0\n"        // 9 fields, reference
+        "K 5 3 1 2 4 0 0 0 1\n"        // 9 fields, driving
+        "SKETCH_END\n";
+    std::istringstream is(body);
+    Sketch sk;
+    materializr::ProjectIO::parseSketchBody(is, sk, "SKETCH_END");
+    ASSERT_EQ(sk.getConstraints().size(), 2u);
+    EXPECT_FALSE(sk.getConstraints()[0].isDriving);
+    EXPECT_TRUE(sk.getConstraints()[1].isDriving);
+
+    // And back out through writeSketchBody, then in again.
+    std::ostringstream os;
+    materializr::ProjectIO::writeSketchBody(os, sk);
+    std::istringstream back(os.str());
+    Sketch sk2;
+    materializr::ProjectIO::parseSketchBody(back, sk2, "SKETCH_END");
+    ASSERT_EQ(sk2.getConstraints().size(), 2u);
+    EXPECT_FALSE(sk2.getConstraints()[0].isDriving);
+    EXPECT_TRUE(sk2.getConstraints()[1].isDriving);
+}
+
+TEST(DimensionPersistence, OutOfRangeConstraintTypeIsDropped) {
+    // A garbage enum int must not be cast into ConstraintType — the solver's
+    // switches have no default arm and the value would be UB.
+    std::string body =
+        "PLANE 0 0 0 0 0 1 1 0 0 0 1 0\n"
+        "POINT_COUNT 2\n"
+        "P 1 0 0 0 0\n"
+        "P 2 4 0 0 0\n"
+        "LINE_COUNT 1\n"
+        "L 3 1 2 0 0\n"
+        "CIRCLE_COUNT 0\n"
+        "ARC_COUNT 0\n"
+        "SPLINE_COUNT 0\n"
+        "POLYGON_COUNT 0\n"
+        "CONSTRAINT_COUNT 2\n"
+        "K 4 999 1 2 4 0 0 0 1\n"      // out of range → dropped
+        "K 5 3 1 2 4 0 0 0 1\n"        // valid Distance → kept
+        "SKETCH_END\n";
+    std::istringstream is(body);
+    Sketch sk;
+    materializr::ProjectIO::parseSketchBody(is, sk, "SKETCH_END");
+    ASSERT_EQ(sk.getConstraints().size(), 1u);
+    EXPECT_EQ(sk.getConstraints()[0].id, 5);
+    EXPECT_EQ(sk.getConstraints()[0].type, ConstraintType::Distance);
 }
 
 TEST(DimensionPersistence, WriteSketchBodyPreservesLabelOffsets) {
@@ -603,4 +835,86 @@ TEST(DimensionResolve, TriangleAltitudeIsNotMirroredDPL) {
     int p3 = sk.addPoint({10.0f, 10.0f});
     int l2 = sk.addLine(p2, p3);
     EXPECT_FALSE(SketchTool::linesParallelWithinDimTol(sk, l1, l2));
+}
+
+TEST(DimensionResolve, CircleCentreToLineIsDistancePointLine) {
+    // Hole-centre-to-edge: the single most common machining dimension. The
+    // circle pick substitutes its centre point.
+    Sketch sk;
+    int la = sk.addPoint({0.0f, 0.0f});
+    int lb = sk.addPoint({20.0f, 0.0f});
+    int ln = sk.addLine(la, lb);
+    int ctr = sk.addPoint({10.0f, 7.0f});
+    int ci  = sk.addCircle(ctr, 2.0);
+
+    auto r = SketchTool::resolveDimension(sk, {DimEntityKind::Circle, ci},
+                                              {DimEntityKind::Line, ln});
+    ASSERT_TRUE(r.valid) << "circle+line must resolve, not be rejected";
+    EXPECT_EQ(r.type, ConstraintType::DistancePointLine);
+    EXPECT_EQ(r.entityA, ctr) << "should measure from the circle's centre";
+    EXPECT_EQ(r.entityB, ln);
+    EXPECT_NEAR(r.measured, 7.0, 1e-6);
+}
+
+TEST(DimensionResolve, CircleCentreToLineIsOrderIndependent) {
+    Sketch sk;
+    int la = sk.addPoint({0.0f, 0.0f});
+    int lb = sk.addPoint({20.0f, 0.0f});
+    int ln = sk.addLine(la, lb);
+    int ctr = sk.addPoint({10.0f, 7.0f});
+    int ci  = sk.addCircle(ctr, 2.0);
+
+    auto r = SketchTool::resolveDimension(sk, {DimEntityKind::Line, ln},
+                                              {DimEntityKind::Circle, ci});
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::DistancePointLine);
+    EXPECT_EQ(r.entityA, ctr);
+    EXPECT_NEAR(r.measured, 7.0, 1e-6);
+}
+
+TEST(DimensionResolve, CircleCentreToPointIsDistance) {
+    Sketch sk;
+    int ctr = sk.addPoint({0.0f, 0.0f});
+    int ci  = sk.addCircle(ctr, 2.0);
+    int p   = sk.addPoint({3.0f, 4.0f});
+
+    auto r = SketchTool::resolveDimension(sk, {DimEntityKind::Circle, ci},
+                                              {DimEntityKind::Point, p});
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::Distance);
+    EXPECT_NEAR(r.measured, 5.0, 1e-6);
+}
+
+TEST(DimensionResolve, ArcCentreToLineWorksToo) {
+    Sketch sk;
+    int la = sk.addPoint({0.0f, 0.0f});
+    int lb = sk.addPoint({20.0f, 0.0f});
+    int ln = sk.addLine(la, lb);
+    int ctr = sk.addPoint({5.0f, 9.0f});
+    int s   = sk.addPoint({8.0f, 9.0f});
+    int e   = sk.addPoint({5.0f, 12.0f});
+    int ar  = sk.addArc(ctr, s, e, 3.0);
+
+    auto r = SketchTool::resolveDimension(sk, {DimEntityKind::Arc, ar},
+                                              {DimEntityKind::Line, ln});
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::DistancePointLine);
+    EXPECT_EQ(r.entityA, ctr);
+    EXPECT_NEAR(r.measured, 9.0, 1e-6);
+}
+
+TEST(DimensionResolve, TwoCirclesStillGiveRimGapNotCentreDistance) {
+    // Regression: the centre-substitution above must not swallow the
+    // circle+circle case, which stays a rim-to-rim gap.
+    Sketch sk;
+    int cA = sk.addPoint({0.0f, 0.0f});
+    int ciA = sk.addCircle(cA, 5.0);
+    int cB = sk.addPoint({20.0f, 0.0f});
+    int ciB = sk.addCircle(cB, 3.0);
+
+    auto r = SketchTool::resolveDimension(sk, {DimEntityKind::Circle, ciA},
+                                              {DimEntityKind::Circle, ciB});
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::CircleGap);
+    EXPECT_NEAR(r.measured, 12.0, 1e-6);
 }

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -54,6 +54,35 @@ TEST(DistancePointLine, ConvergesToTarget) {
     EXPECT_NEAR(pointLineDist(sk, p, ln), 7.0, 1e-3);
 }
 
+TEST(CircleGap, SolverDrivesRimGapToTarget) {
+    // Two circles, centres 20 apart, radii 5 and 3 → gap 12. Constrain the
+    // rim gap to 2: centres should close to 10 apart, radii untouched.
+    Sketch sk;
+    int cA = sk.addPoint({0.0f, 0.0f});
+    int ciA = sk.addCircle(cA, 5.0);
+    int cB = sk.addPoint({20.0f, 0.0f});
+    int ciB = sk.addCircle(cB, 3.0);
+    Constraint c{};
+    c.type = ConstraintType::CircleGap;
+    c.entityA = ciA;
+    c.entityB = ciB;
+    c.value = 2.0;
+    sk.addConstraint(c);
+
+    SketchSolver solver;
+    EXPECT_TRUE(solver.solve(sk, 500, 1e-4));
+    double centreDist = glm::length(sk.getPoint(cA)->pos - sk.getPoint(cB)->pos);
+    EXPECT_NEAR(centreDist, 10.0, 1e-2); // 2 + 5 + 3
+    // Radii are left to their own constraints — unchanged here.
+    double rA = 0, rB = 0;
+    for (const auto& ci : sk.getCircles()) {
+        if (ci.id == ciA) rA = ci.radius;
+        if (ci.id == ciB) rB = ci.radius;
+    }
+    EXPECT_NEAR(rA, 5.0, 1e-9);
+    EXPECT_NEAR(rB, 3.0, 1e-9);
+}
+
 TEST(DistancePointLine, DegenerateLineDoesNotNaN) {
     Sketch sk;
     int a = sk.addPoint({2.0f, 2.0f});
@@ -369,34 +398,19 @@ TEST(DimensionResolve, InvalidCombosAreInvalid) {
     EXPECT_FALSE(r3.valid);
 }
 
-TEST(DimensionResolve, TwoCirclesGiveCenterDistance) {
+TEST(DimensionResolve, TwoCirclesGiveRimGap) {
     Sketch sk;
     int cA = sk.addPoint({0.0f, 0.0f});
     int ciA = sk.addCircle(cA, 5.0);
-    int cB = sk.addPoint({8.0f, 6.0f});
+    int cB = sk.addPoint({8.0f, 6.0f}); // centre distance 10
     int ciB = sk.addCircle(cB, 3.0);
     auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Circle, ciA),
                                           pick(DimEntityKind::Circle, ciB));
     ASSERT_TRUE(r.valid);
-    EXPECT_EQ(r.type, ConstraintType::Distance);
-    EXPECT_EQ(r.entityA, cA); // centre points, not the circles
-    EXPECT_EQ(r.entityB, cB);
-    EXPECT_NEAR(r.measured, 10.0, 1e-6); // sqrt(8^2 + 6^2)
-}
-
-TEST(DimensionResolve, CirclePlusPointGivesCenterToPointDistance) {
-    Sketch sk;
-    int c = sk.addPoint({0.0f, 0.0f});
-    int ci = sk.addCircle(c, 2.0);
-    int p = sk.addPoint({3.0f, 4.0f});
-    // Either pick order resolves to a centre-to-point Distance.
-    auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Circle, ci),
-                                          pick(DimEntityKind::Point, p));
-    ASSERT_TRUE(r.valid);
-    EXPECT_EQ(r.type, ConstraintType::Distance);
-    EXPECT_EQ(r.entityA, p);
-    EXPECT_EQ(r.entityB, c);
-    EXPECT_NEAR(r.measured, 5.0, 1e-6);
+    EXPECT_EQ(r.type, ConstraintType::CircleGap);
+    EXPECT_EQ(r.entityA, ciA); // the circles, not their centre points
+    EXPECT_EQ(r.entityB, ciB);
+    EXPECT_NEAR(r.measured, 2.0, 1e-6); // 10 - 5 - 3
 }
 
 // Degenerate pick: a point that IS an endpoint of the target line measures a

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -197,3 +197,116 @@ TEST(DimensionPersistence, WriteSketchBodyPreservesLabelOffsets) {
     EXPECT_DOUBLE_EQ(lc.labelOffX, 2.5);
     EXPECT_DOUBLE_EQ(lc.labelOffY, -1.75);
 }
+
+#include "modeling/SketchTool.h"
+
+using materializr::DimEntityKind;
+using materializr::DimPick;
+using materializr::PendingDimension;
+using materializr::SketchTool;
+
+namespace {
+
+// 10-unit horizontal line at y=0 and a second line at `deg` degrees from it,
+// plus a free point at (5,3). Returns ids via out-params.
+struct DimFixture {
+    Sketch sk;
+    int pA, pB, lnAB;      // horizontal line
+    int pC, pD, lnCD;      // rotated line
+    int pFree;
+    explicit DimFixture(float deg) {
+        pA = sk.addPoint({0.0f, 0.0f});
+        pB = sk.addPoint({10.0f, 0.0f});
+        lnAB = sk.addLine(pA, pB);
+        float r = deg * 3.14159265358979f / 180.0f;
+        pC = sk.addPoint({0.0f, 5.0f});
+        pD = sk.addPoint({10.0f * std::cos(r), 5.0f + 10.0f * std::sin(r)});
+        lnCD = sk.addLine(pC, pD);
+        pFree = sk.addPoint({5.0f, 3.0f});
+    }
+};
+
+DimPick pick(DimEntityKind k, int id) { return DimPick{k, id}; }
+
+} // namespace
+
+TEST(DimensionResolve, CircleAloneIsRadius) {
+    Sketch sk;
+    int c = sk.addPoint({0.0f, 0.0f});
+    int ci = sk.addCircle(c, 6.5);
+    auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Circle, ci), DimPick{});
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::Radius);
+    EXPECT_EQ(r.entityA, ci);
+    EXPECT_NEAR(r.measured, 6.5, 1e-9);
+}
+
+TEST(DimensionResolve, LineAloneIsEndpointDistance) {
+    DimFixture f(30.0f);
+    auto r = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Line, f.lnAB), DimPick{});
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::Distance);
+    EXPECT_EQ(r.entityA, f.pA);
+    EXPECT_EQ(r.entityB, f.pB);
+    EXPECT_NEAR(r.measured, 10.0, 1e-6);
+}
+
+TEST(DimensionResolve, PointPointIsDistance) {
+    DimFixture f(30.0f);
+    auto r = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Point, f.pA),
+                                          pick(DimEntityKind::Point, f.pFree));
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::Distance);
+    EXPECT_NEAR(r.measured, std::sqrt(25.0 + 9.0), 1e-6);
+}
+
+TEST(DimensionResolve, PointLineEitherOrderIsDistancePointLine) {
+    DimFixture f(30.0f);
+    auto r1 = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Point, f.pFree),
+                                           pick(DimEntityKind::Line, f.lnAB));
+    auto r2 = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Line, f.lnAB),
+                                           pick(DimEntityKind::Point, f.pFree));
+    for (const auto& r : {r1, r2}) {
+        ASSERT_TRUE(r.valid);
+        EXPECT_EQ(r.type, ConstraintType::DistancePointLine);
+        EXPECT_EQ(r.entityA, f.pFree);
+        EXPECT_EQ(r.entityB, f.lnAB);
+        EXPECT_NEAR(r.measured, 3.0, 1e-6);
+    }
+}
+
+TEST(DimensionResolve, ParallelLinesGiveDistance_NonParallelGiveAngle) {
+    DimFixture par(0.5f);   // inside the 1° parallel threshold
+    auto rp = SketchTool::resolveDimension(par.sk, pick(DimEntityKind::Line, par.lnAB),
+                                           pick(DimEntityKind::Line, par.lnCD));
+    ASSERT_TRUE(rp.valid);
+    EXPECT_EQ(rp.type, ConstraintType::DistancePointLine);
+    EXPECT_EQ(rp.entityA, par.pC);   // second line's start point
+    EXPECT_EQ(rp.entityB, par.lnAB); // measured against the first line
+
+    DimFixture ang(30.0f);
+    auto ra = SketchTool::resolveDimension(ang.sk, pick(DimEntityKind::Line, ang.lnAB),
+                                           pick(DimEntityKind::Line, ang.lnCD));
+    ASSERT_TRUE(ra.valid);
+    EXPECT_EQ(ra.type, ConstraintType::Angle);
+    EXPECT_EQ(ra.entityA, ang.lnAB);
+    EXPECT_EQ(ra.entityB, ang.lnCD);
+    EXPECT_NEAR(ra.measured, 30.0 * 3.14159265358979 / 180.0, 1e-4); // signed, B rel A
+}
+
+TEST(DimensionResolve, InvalidCombosAreInvalid) {
+    Sketch sk;
+    int c = sk.addPoint({0.0f, 0.0f});
+    int ci = sk.addCircle(c, 2.0);
+    int p = sk.addPoint({5.0f, 0.0f});
+    // circle + point is out of scope (spec non-goal)
+    auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Circle, ci),
+                                          pick(DimEntityKind::Point, p));
+    EXPECT_FALSE(r.valid);
+    // lone point
+    auto r2 = SketchTool::resolveDimension(sk, pick(DimEntityKind::Point, p), DimPick{});
+    EXPECT_FALSE(r2.valid);
+    // dangling id
+    auto r3 = SketchTool::resolveDimension(sk, pick(DimEntityKind::Line, 9999), DimPick{});
+    EXPECT_FALSE(r3.valid);
+}

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -139,53 +139,61 @@ TEST(DimensionPersistence, KLineRoundTripsTypeAndLabelOffsets) {
 }
 
 TEST(DimensionPersistence, LegacySixFieldKLineDefaultsOffsetsToZero) {
-    // Save with the new writer, then truncate every K line back to the legacy
-    // 6-field form and reload — offsets must default to 0, load must succeed.
-    Document doc;
-    auto sk = std::make_shared<Sketch>();
-    int a = sk->addPoint({0.0f, 0.0f});
-    int b = sk->addPoint({4.0f, 0.0f});
-    sk->addLine(a, b);
+    // Legacy (pre-offset) K lines carry 6 fields; parseSketchBody must
+    // default offsets to 0 and still load the constraint.
+    std::string body =
+        "PLANE 0 0 0 0 0 1 1 0 0 0 1 0\n"
+        "POINT_COUNT 2\n"
+        "P 1 0 0 0 0\n"
+        "P 2 4 0 0 0\n"
+        "LINE_COUNT 1\n"
+        "L 3 1 2 0 0\n"
+        "CIRCLE_COUNT 0\n"
+        "ARC_COUNT 0\n"
+        "SPLINE_COUNT 0\n"
+        "POLYGON_COUNT 0\n"
+        "CONSTRAINT_COUNT 1\n"
+        "K 4 3 1 2 4 0\n"          // 6 fields, no offsets — ConstraintType 3 = Distance
+        "SKETCH_END\n";
+    std::istringstream is(body);
+    Sketch sk;
+    materializr::ProjectIO::parseSketchBody(is, sk, "SKETCH_END");
+    ASSERT_EQ(sk.getConstraints().size(), 1u);
+    EXPECT_EQ(sk.getConstraints()[0].type, ConstraintType::Distance);
+    EXPECT_DOUBLE_EQ(sk.getConstraints()[0].value, 4.0);
+    EXPECT_DOUBLE_EQ(sk.getConstraints()[0].labelOffX, 0.0);
+    EXPECT_DOUBLE_EQ(sk.getConstraints()[0].labelOffY, 0.0);
+}
+
+TEST(DimensionPersistence, WriteSketchBodyPreservesLabelOffsets) {
+    // writeSketchBody is used by SketchEditOp for undo/redo snapshots.
+    // Verify that label offsets roundtrip through it.
+    Sketch sk;
+    int a = sk.addPoint({0.0f, 0.0f});
+    int b = sk.addPoint({10.0f, 0.0f});
+    int ln = sk.addLine(a, b);
+    int p = sk.addPoint({5.0f, 3.0f});
     Constraint c{};
-    c.type = ConstraintType::Distance;
-    c.entityA = a;
-    c.entityB = b;
-    c.value = 4.0;
-    c.labelOffX = 9.0; // will be stripped below
-    c.labelOffY = 9.0;
-    sk->addConstraint(c);
-    doc.addSketch(sk, "legacy");
+    c.type = ConstraintType::DistancePointLine;
+    c.entityA = p;
+    c.entityB = ln;
+    c.value = 3.0;
+    c.labelOffX = 2.5;
+    c.labelOffY = -1.75;
+    sk.addConstraint(c);
 
-    std::string path = tmpProjectPath("dim_legacy.mzr");
-    ASSERT_TRUE(ProjectIO::save(path, doc).success);
+    // Serialize via writeSketchBody
+    std::stringstream ss;
+    materializr::ProjectIO::writeSketchBody(ss, sk);
 
-    // Strip trailing fields from K lines: keep "K id type eA eB value valueY".
-    std::ifstream in(path);
-    std::stringstream out;
-    std::string line;
-    while (std::getline(in, line)) {
-        if (line.rfind("K ", 0) == 0) {
-            std::istringstream ls(line);
-            std::string tok, kept;
-            for (int i = 0; i < 7 && (ls >> tok); ++i) { // "K" + 6 fields
-                if (i) kept += ' ';
-                kept += tok;
-            }
-            out << kept << '\n';
-        } else {
-            out << line << '\n';
-        }
-    }
-    in.close();
-    std::ofstream ow(path, std::ios::trunc);
-    ow << out.str();
-    ow.close();
+    // Deserialize via parseSketchBody
+    Sketch loaded;
+    materializr::ProjectIO::parseSketchBody(ss, loaded, "SKETCH_END");
 
-    Document loaded;
-    ASSERT_TRUE(ProjectIO::load(path, loaded).success);
-    std::remove(path.c_str());
-    auto lsk = loaded.getSketch(loaded.getAllSketchIds()[0]);
-    ASSERT_EQ(lsk->getConstraints().size(), 1u);
-    EXPECT_DOUBLE_EQ(lsk->getConstraints()[0].labelOffX, 0.0);
-    EXPECT_DOUBLE_EQ(lsk->getConstraints()[0].labelOffY, 0.0);
+    ASSERT_EQ(loaded.getConstraints().size(), 1u);
+    const Constraint& lc = loaded.getConstraints()[0];
+    EXPECT_EQ(lc.type, ConstraintType::DistancePointLine);
+    EXPECT_DOUBLE_EQ(lc.value, 3.0);
+    EXPECT_DOUBLE_EQ(lc.labelOffX, 2.5);
+    EXPECT_DOUBLE_EQ(lc.labelOffY, -1.75);
 }

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -418,3 +418,49 @@ TEST(DimensionResolve, ParallelThresholdBoundary) {
     ASSERT_TRUE(pastThreshold.valid);
     EXPECT_EQ(pastThreshold.type, ConstraintType::Angle);
 }
+
+// linesParallelWithinDimTol is the shared "same tolerance as
+// resolveDimension's line-line branch" helper the mirrored-DistancePointLine
+// dedup in Application::applyPendingDimension gates on (Application-level
+// logic remains untestable here per the established exception; this
+// standalone helper is the part of that fix that IS unit-testable).
+TEST(DimensionResolve, LinesParallelWithinDimTol) {
+    DimFixture par(0.5f);   // inside the 1 deg threshold
+    EXPECT_TRUE(SketchTool::linesParallelWithinDimTol(par.sk, par.lnAB, par.lnCD));
+
+    DimFixture ang(30.0f);  // well past the threshold
+    EXPECT_FALSE(SketchTool::linesParallelWithinDimTol(ang.sk, ang.lnAB, ang.lnCD));
+
+    DimFixture anti(179.5f); // anti-parallel: folds to 0.5 deg, inside threshold
+    EXPECT_TRUE(SketchTool::linesParallelWithinDimTol(anti.sk, anti.lnAB, anti.lnCD));
+
+    // Dangling / self / degenerate inputs are all false, not crashes.
+    EXPECT_FALSE(SketchTool::linesParallelWithinDimTol(par.sk, par.lnAB, 9999));
+    Sketch degenerate;
+    int dp1 = degenerate.addPoint({0.0f, 0.0f});
+    int dp2 = degenerate.addPoint({0.0f, 0.0f}); // zero-length line
+    int dln = degenerate.addLine(dp1, dp2);
+    int dp3 = degenerate.addPoint({5.0f, 0.0f});
+    int dp4 = degenerate.addPoint({10.0f, 0.0f});
+    int dln2 = degenerate.addLine(dp3, dp4);
+    EXPECT_FALSE(SketchTool::linesParallelWithinDimTol(degenerate, dln, dln2));
+}
+
+// The triangle-altitude scenario the parallel gate exists to prevent: two
+// lines sharing endpoint p2 but at a real (non-parallel) angle. Dimensioning
+// p1-to-L2 then, separately, p2-to-L1 satisfies the OLD mirrored-DPL
+// endpoint-membership check (each picked point is an endpoint of the OTHER
+// line) but is not the same physical gap — the fix's parallel gate must
+// reject it so applyPendingDimension (untestable here) falls through to
+// adding a second, independent constraint instead of overwriting the first.
+TEST(DimensionResolve, TriangleAltitudeIsNotMirroredDPL) {
+    Sketch sk;
+    // A right-angle-ish triangle: L1 = p1-p2 (horizontal), L2 = p2-p3
+    // (vertical) — 90 deg apart, nowhere near the 1 deg parallel tolerance.
+    int p1 = sk.addPoint({0.0f, 0.0f});
+    int p2 = sk.addPoint({10.0f, 0.0f});
+    int l1 = sk.addLine(p1, p2);
+    int p3 = sk.addPoint({10.0f, 10.0f});
+    int l2 = sk.addLine(p2, p3);
+    EXPECT_FALSE(SketchTool::linesParallelWithinDimTol(sk, l1, l2));
+}

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -54,6 +54,53 @@ TEST(DistancePointLine, ConvergesToTarget) {
     EXPECT_NEAR(pointLineDist(sk, p, ln), 7.0, 1e-3);
 }
 
+TEST(EqualConstraint, EqualisesCircleRadii) {
+    // Equal on two circle ids drives both radii to their average.
+    Sketch sk;
+    int ca = sk.addPoint({0.0f, 0.0f});
+    int ciA = sk.addCircle(ca, 4.0);
+    int cb = sk.addPoint({20.0f, 0.0f});
+    int ciB = sk.addCircle(cb, 10.0);
+    Constraint c{};
+    c.type = ConstraintType::Equal;
+    c.entityA = ciA;
+    c.entityB = ciB;
+    sk.addConstraint(c);
+
+    SketchSolver solver;
+    EXPECT_TRUE(solver.solve(sk, 500, 1e-4));
+    double rA = 0, rB = 0;
+    for (const auto& ci : sk.getCircles()) {
+        if (ci.id == ciA) rA = ci.radius;
+        if (ci.id == ciB) rB = ci.radius;
+    }
+    EXPECT_NEAR(rA, 7.0, 1e-3); // (4 + 10) / 2
+    EXPECT_NEAR(rB, 7.0, 1e-3);
+}
+
+TEST(EqualConstraint, StillEqualisesLineLengths) {
+    // Regression: Equal on two line ids keeps meaning equal length.
+    Sketch sk;
+    int a = sk.addPoint({0.0f, 0.0f});
+    int b = sk.addPoint({4.0f, 0.0f});
+    int lnA = sk.addLine(a, b);
+    int cc = sk.addPoint({0.0f, 5.0f});
+    int dd = sk.addPoint({0.0f, 15.0f}); // length 10
+    int lnB = sk.addLine(cc, dd);
+    Constraint c{};
+    c.type = ConstraintType::Equal;
+    c.entityA = lnA;
+    c.entityB = lnB;
+    sk.addConstraint(c);
+
+    SketchSolver solver;
+    EXPECT_TRUE(solver.solve(sk, 500, 1e-4));
+    double lenA = glm::length(sk.getPoint(a)->pos - sk.getPoint(b)->pos);
+    double lenB = glm::length(sk.getPoint(cc)->pos - sk.getPoint(dd)->pos);
+    EXPECT_NEAR(lenA, lenB, 1e-2);
+    EXPECT_NEAR(lenA, 7.0, 1e-2); // (4 + 10) / 2
+}
+
 TEST(CircleGap, SolverDrivesRimGapToTarget) {
     // Two circles, centres 20 apart, radii 5 and 3 → gap 12. Constrain the
     // rim gap to 2: centres should close to 10 apart, radii untouched.

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -101,6 +101,40 @@ TEST(EqualConstraint, StillEqualisesLineLengths) {
     EXPECT_NEAR(lenA, 7.0, 1e-2); // (4 + 10) / 2
 }
 
+TEST(RectangleRigidity, AddRectangleCarriesHVConstraints) {
+    Sketch sk;
+    sk.addRectangle({0.0f, 0.0f}, {10.0f, 6.0f});
+    int nH = 0, nV = 0;
+    for (const auto& c : sk.getConstraints()) {
+        if (c.type == ConstraintType::Horizontal) ++nH;
+        if (c.type == ConstraintType::Vertical) ++nV;
+    }
+    EXPECT_EQ(nH, 2);
+    EXPECT_EQ(nV, 2);
+}
+
+TEST(RectangleRigidity, StaysSquareWhenACornerIsPulled) {
+    // A rectangle whose corner is dragged (as a distance dim would) must stay
+    // rectangular — sides horizontal/vertical — not skew into a parallelogram.
+    Sketch sk;
+    sk.addRectangle({0.0f, 0.0f}, {10.0f, 6.0f});
+    // Pull the top-right corner off-axis, then solve: H/V constraints re-square.
+    const auto& pts = sk.getPoints();
+    ASSERT_GE(pts.size(), 4u);
+    // The 3rd point (corner2) — nudge it diagonally.
+    int cornerId = pts[2].id;
+    sk.movePoint(cornerId, pts[2].pos + glm::vec2(3.0f, 2.5f));
+    SketchSolver solver;
+    solver.solve(sk, 500, 1e-4);
+    // Every line must be axis-aligned (dx≈0 or dy≈0).
+    for (const auto& l : sk.getLines()) {
+        glm::vec2 d = sk.getPoint(l.endPointId)->pos - sk.getPoint(l.startPointId)->pos;
+        bool axis = std::abs(d.x) < 1e-2f || std::abs(d.y) < 1e-2f;
+        EXPECT_TRUE(axis) << "line " << l.id << " not axis-aligned: "
+                          << d.x << "," << d.y;
+    }
+}
+
 TEST(CircleGap, SolverDrivesRimGapToTarget) {
     // Two circles, centres 20 apart, radii 5 and 3 → gap 12. Constrain the
     // rim gap to 2: centres should close to 10 apart, radii untouched.

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -79,3 +79,113 @@ TEST(DistancePointLine, MissingEntitiesAreInert) {
     EXPECT_NEAR(sk.getPoint(p)->pos.x, 1.0f, 1e-6);
     EXPECT_NEAR(sk.getPoint(p)->pos.y, 1.0f, 1e-6);
 }
+
+#include "core/Document.h"
+#include "io/ProjectIO.h"
+
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <sstream>
+
+using materializr::ProjectIO;
+
+namespace {
+
+std::string tmpProjectPath(const char* name) {
+    const char* t = std::getenv("TMPDIR");
+    std::string dir = t ? t : "/tmp";
+    if (!dir.empty() && dir.back() != '/') dir += '/';
+    return dir + name;
+}
+
+} // namespace
+
+TEST(DimensionPersistence, KLineRoundTripsTypeAndLabelOffsets) {
+    Document doc;
+    auto sk = std::make_shared<Sketch>();
+    int a = sk->addPoint({0.0f, 0.0f});
+    int b = sk->addPoint({10.0f, 0.0f});
+    int ln = sk->addLine(a, b);
+    int p = sk->addPoint({5.0f, 3.0f});
+    Constraint c{};
+    c.type = ConstraintType::DistancePointLine;
+    c.entityA = p;
+    c.entityB = ln;
+    c.value = 3.0;
+    c.labelOffX = 1.5;
+    c.labelOffY = -2.25;
+    sk->addConstraint(c);
+    doc.addSketch(sk, "dim-test");
+
+    std::string path = tmpProjectPath("dim_roundtrip.mzr");
+    ASSERT_TRUE(ProjectIO::save(path, doc).success);
+
+    Document loaded;
+    ASSERT_TRUE(ProjectIO::load(path, loaded).success);
+    std::remove(path.c_str());
+
+    // First (only) sketch in the loaded doc.
+    auto ids = loaded.getAllSketchIds();
+    ASSERT_EQ(ids.size(), 1u);
+    auto lsk = loaded.getSketch(ids[0]);
+    ASSERT_TRUE(lsk);
+    ASSERT_EQ(lsk->getConstraints().size(), 1u);
+    const Constraint& lc = lsk->getConstraints()[0];
+    EXPECT_EQ(lc.type, ConstraintType::DistancePointLine);
+    EXPECT_DOUBLE_EQ(lc.value, 3.0);
+    EXPECT_DOUBLE_EQ(lc.labelOffX, 1.5);
+    EXPECT_DOUBLE_EQ(lc.labelOffY, -2.25);
+}
+
+TEST(DimensionPersistence, LegacySixFieldKLineDefaultsOffsetsToZero) {
+    // Save with the new writer, then truncate every K line back to the legacy
+    // 6-field form and reload — offsets must default to 0, load must succeed.
+    Document doc;
+    auto sk = std::make_shared<Sketch>();
+    int a = sk->addPoint({0.0f, 0.0f});
+    int b = sk->addPoint({4.0f, 0.0f});
+    sk->addLine(a, b);
+    Constraint c{};
+    c.type = ConstraintType::Distance;
+    c.entityA = a;
+    c.entityB = b;
+    c.value = 4.0;
+    c.labelOffX = 9.0; // will be stripped below
+    c.labelOffY = 9.0;
+    sk->addConstraint(c);
+    doc.addSketch(sk, "legacy");
+
+    std::string path = tmpProjectPath("dim_legacy.mzr");
+    ASSERT_TRUE(ProjectIO::save(path, doc).success);
+
+    // Strip trailing fields from K lines: keep "K id type eA eB value valueY".
+    std::ifstream in(path);
+    std::stringstream out;
+    std::string line;
+    while (std::getline(in, line)) {
+        if (line.rfind("K ", 0) == 0) {
+            std::istringstream ls(line);
+            std::string tok, kept;
+            for (int i = 0; i < 7 && (ls >> tok); ++i) { // "K" + 6 fields
+                if (i) kept += ' ';
+                kept += tok;
+            }
+            out << kept << '\n';
+        } else {
+            out << line << '\n';
+        }
+    }
+    in.close();
+    std::ofstream ow(path, std::ios::trunc);
+    ow << out.str();
+    ow.close();
+
+    Document loaded;
+    ASSERT_TRUE(ProjectIO::load(path, loaded).success);
+    std::remove(path.c_str());
+    auto lsk = loaded.getSketch(loaded.getAllSketchIds()[0]);
+    ASSERT_EQ(lsk->getConstraints().size(), 1u);
+    EXPECT_DOUBLE_EQ(lsk->getConstraints()[0].labelOffX, 0.0);
+    EXPECT_DOUBLE_EQ(lsk->getConstraints()[0].labelOffY, 0.0);
+}

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -337,6 +337,27 @@ TEST(DimensionResolve, AntiParallelLinesGiveDistance) {
     EXPECT_EQ(r.entityB, f.lnAB);
 }
 
+TEST(DimensionResolve, ParallelPickPrefersEndpointOverFirstSegment) {
+    // Second line drawn so its START's perpendicular foot lands past the
+    // first segment's end (t≈1.5) while its END's foot lands inside (t≈0.5).
+    // The dim must pin the END point, or the label hangs off to the side
+    // over unrelated geometry (the rectangle "third line" bug).
+    Sketch sk;
+    int a = sk.addPoint({0.0f, 0.0f});
+    int b = sk.addPoint({10.0f, 0.0f});
+    int lnA = sk.addLine(a, b);
+    int cS = sk.addPoint({15.0f, 5.0f});
+    int cE = sk.addPoint({5.0f, 5.0f});
+    int lnC = sk.addLine(cS, cE);
+    auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Line, lnA),
+                                          pick(DimEntityKind::Line, lnC));
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::DistancePointLine);
+    EXPECT_EQ(r.entityA, cE); // endpoint whose foot is inside the first segment
+    EXPECT_EQ(r.entityB, lnA);
+    EXPECT_NEAR(r.measured, 5.0, 1e-6);
+}
+
 TEST(DimensionResolve, InvalidCombosAreInvalid) {
     Sketch sk;
     int c = sk.addPoint({0.0f, 0.0f});

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -1,0 +1,81 @@
+// DistancePointLine: perpendicular distance from a point (entityA) to the
+// infinite line carried by a sketch line (entityB). Solver drives the point
+// and the line's endpoints apart/together along the line normal.
+
+#include "modeling/Sketch.h"
+#include "modeling/SketchSolver.h"
+
+#include <gtest/gtest.h>
+#include <glm/glm.hpp>
+#include <cmath>
+
+using materializr::Constraint;
+using materializr::ConstraintType;
+using materializr::Sketch;
+using materializr::SketchSolver;
+
+namespace {
+
+double pointLineDist(const Sketch& sk, int ptId, int lineId) {
+    const auto* p = sk.getPoint(ptId);
+    for (const auto& l : sk.getLines()) {
+        if (l.id != lineId) continue;
+        const auto* a = sk.getPoint(l.startPointId);
+        const auto* b = sk.getPoint(l.endPointId);
+        glm::vec2 d = b->pos - a->pos;
+        glm::vec2 r = p->pos - a->pos;
+        return std::abs(d.x * r.y - d.y * r.x) / glm::length(d);
+    }
+    return -1.0;
+}
+
+Constraint makeDPL(int ptId, int lineId, double value) {
+    Constraint c{};
+    c.id = 0;
+    c.type = ConstraintType::DistancePointLine;
+    c.entityA = ptId;
+    c.entityB = lineId;
+    c.value = value;
+    return c;
+}
+
+} // namespace
+
+TEST(DistancePointLine, ConvergesToTarget) {
+    Sketch sk;
+    int a = sk.addPoint({0.0f, 0.0f});
+    int b = sk.addPoint({10.0f, 0.0f});
+    int ln = sk.addLine(a, b);
+    int p = sk.addPoint({5.0f, 3.0f});
+    sk.addConstraint(makeDPL(p, ln, 7.0));
+
+    SketchSolver solver;
+    EXPECT_TRUE(solver.solve(sk, 500, 1e-4));
+    EXPECT_NEAR(pointLineDist(sk, p, ln), 7.0, 1e-3);
+}
+
+TEST(DistancePointLine, DegenerateLineDoesNotNaN) {
+    Sketch sk;
+    int a = sk.addPoint({2.0f, 2.0f});
+    int b = sk.addPoint({2.0f, 2.0f}); // zero-length line
+    int ln = sk.addLine(a, b);
+    int p = sk.addPoint({5.0f, 3.0f});
+    sk.addConstraint(makeDPL(p, ln, 4.0));
+
+    SketchSolver solver;
+    solver.solve(sk, 100, 1e-4); // must not crash or NaN, return value unspecified
+    for (const auto& pt : sk.getPoints()) {
+        EXPECT_TRUE(std::isfinite(pt.pos.x));
+        EXPECT_TRUE(std::isfinite(pt.pos.y));
+    }
+}
+
+TEST(DistancePointLine, MissingEntitiesAreInert) {
+    Sketch sk;
+    int p = sk.addPoint({1.0f, 1.0f});
+    sk.addConstraint(makeDPL(p, 9999, 4.0)); // no such line
+    SketchSolver solver;
+    solver.solve(sk, 50, 1e-4);
+    EXPECT_NEAR(sk.getPoint(p)->pos.x, 1.0f, 1e-6);
+    EXPECT_NEAR(sk.getPoint(p)->pos.y, 1.0f, 1e-6);
+}

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -294,6 +294,17 @@ TEST(DimensionResolve, ParallelLinesGiveDistance_NonParallelGiveAngle) {
     EXPECT_NEAR(ra.measured, 30.0 * 3.14159265358979 / 180.0, 1e-4); // signed, B rel A
 }
 
+TEST(DimensionResolve, AntiParallelLinesGiveDistance) {
+    // 179.5° apart folds to 0.5° — inside the parallel threshold.
+    DimFixture f(179.5f);
+    auto r = SketchTool::resolveDimension(f.sk, pick(DimEntityKind::Line, f.lnAB),
+                                          pick(DimEntityKind::Line, f.lnCD));
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::DistancePointLine);
+    EXPECT_EQ(r.entityA, f.pC);
+    EXPECT_EQ(r.entityB, f.lnAB);
+}
+
 TEST(DimensionResolve, InvalidCombosAreInvalid) {
     Sketch sk;
     int c = sk.addPoint({0.0f, 0.0f});

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -360,19 +360,43 @@ TEST(DimensionResolve, ParallelPickPrefersEndpointOverFirstSegment) {
 
 TEST(DimensionResolve, InvalidCombosAreInvalid) {
     Sketch sk;
-    int c = sk.addPoint({0.0f, 0.0f});
-    int ci = sk.addCircle(c, 2.0);
     int p = sk.addPoint({5.0f, 0.0f});
-    // circle + point is out of scope (spec non-goal)
-    auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Circle, ci),
-                                          pick(DimEntityKind::Point, p));
-    EXPECT_FALSE(r.valid);
     // lone point
     auto r2 = SketchTool::resolveDimension(sk, pick(DimEntityKind::Point, p), DimPick{});
     EXPECT_FALSE(r2.valid);
     // dangling id
     auto r3 = SketchTool::resolveDimension(sk, pick(DimEntityKind::Line, 9999), DimPick{});
     EXPECT_FALSE(r3.valid);
+}
+
+TEST(DimensionResolve, TwoCirclesGiveCenterDistance) {
+    Sketch sk;
+    int cA = sk.addPoint({0.0f, 0.0f});
+    int ciA = sk.addCircle(cA, 5.0);
+    int cB = sk.addPoint({8.0f, 6.0f});
+    int ciB = sk.addCircle(cB, 3.0);
+    auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Circle, ciA),
+                                          pick(DimEntityKind::Circle, ciB));
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::Distance);
+    EXPECT_EQ(r.entityA, cA); // centre points, not the circles
+    EXPECT_EQ(r.entityB, cB);
+    EXPECT_NEAR(r.measured, 10.0, 1e-6); // sqrt(8^2 + 6^2)
+}
+
+TEST(DimensionResolve, CirclePlusPointGivesCenterToPointDistance) {
+    Sketch sk;
+    int c = sk.addPoint({0.0f, 0.0f});
+    int ci = sk.addCircle(c, 2.0);
+    int p = sk.addPoint({3.0f, 4.0f});
+    // Either pick order resolves to a centre-to-point Distance.
+    auto r = SketchTool::resolveDimension(sk, pick(DimEntityKind::Circle, ci),
+                                          pick(DimEntityKind::Point, p));
+    ASSERT_TRUE(r.valid);
+    EXPECT_EQ(r.type, ConstraintType::Distance);
+    EXPECT_EQ(r.entityA, p);
+    EXPECT_EQ(r.entityB, c);
+    EXPECT_NEAR(r.measured, 5.0, 1e-6);
 }
 
 // Degenerate pick: a point that IS an endpoint of the target line measures a


### PR DESCRIPTION
## What this does

Adds a Dimension tool to sketch mode (`d`, plus a toolbar button): pick one or
two entities, place the label, optionally type a value. It covers line length,
circle diameter, arc radius, point-to-point, point-to-line, parallel
line-to-line gap, angle between non-parallel lines, circle rim-to-rim gap, and
circle/arc centre to a line or point.

**Dimensions are reference (annotation) by default.** Placing one measures the
geometry without moving it: the solver skips it, it costs no degree of freedom,
and it re-measures itself after every solve, so a label always reports what it
points at. Reference labels render bracketed and grey per drafting convention.
The label's edit popup carries a `Driving` checkbox to promote one; typing a
value promotes it too, on the reasoning that typing a number is a statement that
it should control the shape.

`Constraint::isDriving` defaults to **true**, so every existing constraint — in
memory, in saved files, and every geometric type where "reference" is
meaningless — keeps driving exactly as before. Only the Dimension tool clears
it. The `K` line gains a 9th field; 6- and 8-field lines from older builds load
as driving, and older builds ignore the trailing token.

Two bugs fixed along the way, both reachable from this tool:

- **`Radius` on an arc never solved.** `computeError` scanned only
  `getCircles()`, so an arc id returned residual 0 ("already satisfied") and
  `applyCorrection`'s arc branch was unreachable dead code — the radius never
  moved while `solve()` returned true and the label rendered the *typed* value.
  A 10 mm arc could be labelled 16 mm on a drawing.
- **A circle/arc centre could not be dimensioned to a line or point.**
  `hitTestDimEntity` resolves a centre click to its circle so the rim-gap dim
  stays reachable, which left the centre unpickable and made hole-centre-to-edge
  impossible. `resolveDimension` now substitutes the centre for curve+line and
  curve+point; two curves still give the rim gap.

Smaller corrections: arcs are labelled `R`, circles `Ø` (they previously shared
the diameter form); refused dimension picks report why instead of failing
silently; `Make equal` in the popup converts a two-entity dimension into an
`Equal` constraint on the same pair; and the constraint reader now range-checks
the serialized type before casting it, since an out-of-range value is undefined
behaviour and the solver switches have no default arm.

## How it was tested

- `cmake --build build` (Release) clean, then `ctest --test-dir build` — **48/48
  suites pass**, of which `test_sketch_dimension` is 41 tests. Run unsandboxed;
  a sandboxed run false-fails the file-IO suites on `/tmp` writes.
- New tests cover: reference dims don't drive, re-measure themselves, and cost
  no DOF (each with a driving control); arc `Radius` drives (with a circle
  control); centre-to-line/point resolution including arcs and order
  independence; two circles still resolving to a rim gap; legacy 6- and 8-field
  `K` lines loading as driving; `isDriving` round-tripping; out-of-range
  constraint type dropped.
- Manually verified in the running app on macOS: into sketch mode, drew a line,
  placed a dimension, confirmed the label renders `[100.00 mm]` bracketed and
  grey with `Driving` unchecked, then toggled `Driving` and confirmed the label
  turns amber, loses its brackets, and produces an undo step.

## Checklist

- [x] Builds on desktop and tests pass (`ctest`) — 48/48
- [ ] **Not verified on Android.** The changed files are all in the Android
      source glob, and nothing here is platform-specific or touch-specific, but
      I did not cross-build the APK. Worth a check before merge.
- [x] The tool is registered through `src/plugins/SketchPlugin.cpp`, alongside
      the other sketch tools
- [x] No `#if __ANDROID__` added; no touch-specific branches introduced
- [x] Code matches the style of the surrounding files

## Notes for review

The branch was rebased onto current `main`, so it applies cleanly.

Reference-by-default is a deliberate departure from the original design doc in
`docs/superpowers/specs/`, which listed driven/reference dimensions as a
non-goal. The change is what makes the tool usable for measuring an
under-constrained sketch without deforming it; the old behaviour is one
checkbox away.
