### PR TITLE
ci: run on pull requests, and run tests on Windows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,6 +12,13 @@ on:
       - 'docs/**'
       - 'packaging/**'
       - '.github/workflows/windows.yml'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'packaging/**'
+      - '.github/workflows/windows.yml'
   workflow_dispatch:
   release:
     types: [ published ]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,8 +6,20 @@ name: macOS Build
 # published GitHub Release it also attaches the .dmg. The Linux/Windows/Android
 # builds are unaffected.
 
+# pull_request matters most here: this is the ONLY job that runs ctest, so
+# before it ran on PRs a contribution was first tested after it had already
+# been merged to main.
 on:
   push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'android/**'
+      - 'scripts/**'
+      - '.github/workflows/linux.yml'
+      - '.github/workflows/windows.yml'
+  pull_request:
     branches: [ main ]
     paths-ignore:
       - '**.md'
@@ -20,7 +32,8 @@ on:
   release:
     types: [ published ]
 
-# A newer push on main cancels an in-flight build — older runs wouldn't ship.
+# A newer push on main (or a new commit on a PR) cancels an in-flight build —
+# older runs wouldn't ship, and a superseded PR result is noise.
 concurrency:
   group: macos-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,9 +10,20 @@ on:
     paths-ignore:
       - '**.md'
       - 'scripts/**'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'scripts/**'
   workflow_dispatch:
   release:
     types: [ published ]
+
+# A new commit on a PR (or on main) cancels the in-flight run for that ref.
+# This job is the long one, so superseded runs are worth cancelling.
+concurrency:
+  group: windows-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   windows:
@@ -31,7 +42,13 @@ jobs:
       # OCCT (and friends) into the feed; subsequent builds download the
       # binaries instead of recompiling, dropping OCCT's ~1h cold compile to
       # a few minutes. Replaces the now-removed `x-gha` backend.
-      VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
+      #
+      # READ-ONLY on pull requests. A PR from a fork gets a read-only
+      # GITHUB_TOKEN, so a `readwrite` push would fail the step; and PR builds
+      # shouldn't be able to write the cache that later main builds consume
+      # anyway — that would let an untrusted PR poison a trusted build.
+      VCPKG_BINARY_SOURCES: >-
+        clear;nuget,GitHub,${{ github.event_name == 'pull_request' && 'read' || 'readwrite' }}
       # Where the NuGet feed lives. Per-org URL; ${{ github.repository_owner }}
       # resolves to materializr-cad for this repo, but stays correct on forks.
       NUGET_FEED_URL: "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
@@ -43,7 +60,14 @@ jobs:
       # GITHUB_TOKEN is the workflow's own short-lived token; with the
       # `packages: write` permission above it can both pull cached binaries
       # and push new ones.
+      #
+      # Skipped for PRs from a FORK: that token cannot authenticate to this
+      # org's feed at all, so configuring the source would only produce 401s on
+      # every restore. Those runs compile the dependencies from source instead —
+      # slow (OCCT is ~1h cold) but correct. Same-repo PRs keep the cache and
+      # stay fast.
       - name: Configure vcpkg binary cache (GitHub Packages NuGet feed)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         shell: pwsh
         run: |
           $nuget = & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" fetch nuget | Select-Object -Last 1
@@ -65,6 +89,10 @@ jobs:
           & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" x-update-baseline
           & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install --triplet x64-windows
 
+      # BUILD_TESTS=ON: this build used to skip the test suite entirely, so
+      # every Windows-specific code path (the _WIN32 branches in
+      # ProjectRecovery, url_open.h, portable-file-dialogs) shipped without a
+      # single test having run against it on Windows.
       - name: Configure
         shell: pwsh
         run: |
@@ -72,11 +100,18 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=x64-windows `
             -DVCPKG_MANIFEST_MODE=ON `
-            -DBUILD_TESTS=OFF
+            -DBUILD_TESTS=ON
 
       - name: Build
         shell: pwsh
         run: cmake --build build --config Release --parallel
+
+      # -C Release: the Visual Studio generator is multi-config, so ctest needs
+      # the configuration named explicitly or it finds no tests to run and
+      # exits 0 — a green check that verified nothing.
+      - name: Test
+        shell: pwsh
+        run: ctest --test-dir build -C Release --output-on-failure
 
       - name: Stage portable package
         shell: pwsh
@@ -106,14 +141,23 @@ jobs:
           name: Materializr-windows-x64-portable
           path: Materializr-windows-x64.zip
 
+      # APPVERSION goes through the environment, not through `${{ }}` inline in
+      # the command line. Actions expands `${{ }}` textually BEFORE pwsh parses
+      # the line, and git ref names may legally contain `"`, `;`, `$` and
+      # backticks — enough to close the quoted string and append a statement, in
+      # a job that holds contents/packages write. Reading $env: instead removes
+      # that path entirely. (It also keeps the ref out of the command line now
+      # that PRs run this, where ref_name is "<number>/merge".)
       - name: Build installer (NSIS)
         shell: pwsh
+        env:
+          APPVERSION: ${{ github.ref_name }}
         run: |
           choco install nsis -y --no-progress
           & "C:\Program Files (x86)\NSIS\makensis.exe" `
             "/DSTAGING=$PWD\staging\Materializr" `
             "/DOUTFILE=$PWD\Materializr-Setup.exe" `
-            "/DAPPVERSION=${{ github.ref_name }}" `
+            "/DAPPVERSION=$env:APPVERSION" `
             packaging\windows\installer.nsi
 
       - name: Upload installer artifact

--- a/tests/test_audit_hardening.cpp
+++ b/tests/test_audit_hardening.cpp
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include "test_tmp_path.h"
 
 using materializr::AppSettings;
 using materializr::SvgImport;
@@ -32,10 +33,9 @@ using materializr::SvgPaths;
 namespace {
 
 std::string tempPath(const char* name) {
-    const char* dir = std::getenv("TMPDIR");
-    std::string base = (dir && *dir) ? dir : "/tmp";
-    if (!base.empty() && base.back() != '/') base += '/';
-    return base + name;
+    // temp_directory_path() honours TMPDIR on POSIX and TEMP/TMP on Windows,
+    // where the old "/tmp" fallback was an unwritable path.
+    return mzrtest::tmpPath(name);
 }
 
 void writeFile(const std::string& path, const std::string& text) {

--- a/tests/test_brepio_dos.cpp
+++ b/tests/test_brepio_dos.cpp
@@ -18,14 +18,14 @@
 #include <cstdio>
 #include <fstream>
 #include <string>
+#include "test_tmp_path.h"
 
 namespace {
 
 std::string tempPath(const char* name) {
-    const char* dir = std::getenv("TMPDIR");
-    std::string base = (dir && *dir) ? dir : "/tmp";
-    if (!base.empty() && base.back() != '/') base += '/';
-    return base + name;
+    // temp_directory_path() honours TMPDIR on POSIX and TEMP/TMP on Windows,
+    // where the old "/tmp" fallback was an unwritable path.
+    return mzrtest::tmpPath(name);
 }
 
 void writeFile(const std::string& path, const std::string& text) {

--- a/tests/test_full_replay.cpp
+++ b/tests/test_full_replay.cpp
@@ -52,6 +52,7 @@
 #include <cstdio>
 #include <map>
 #include <memory>
+#include "test_tmp_path.h"
 
 using materializr::Sketch;
 using namespace materializr;
@@ -391,7 +392,7 @@ TEST(FullReplay, EveryOpReloadsEditableAndChainReplays) {
     // ── Save through the real ProjectIO, load into a fresh document. ──
     ProjectHistory saved = captureHistory(hist, doc);
     ASSERT_EQ(static_cast<int>(saved.steps.size()), nSteps);
-    const std::string path = "/tmp/mtz_full_replay.materializr";
+    const std::string path = mzrtest::tmpPath("mtz_full_replay.materializr");
     ASSERT_TRUE(ProjectIO::save(path, doc, &saved).success);
     Document doc2;
     ProjectHistory loaded;

--- a/tests/test_recovery.cpp
+++ b/tests/test_recovery.cpp
@@ -89,7 +89,18 @@ struct Env {
                             fs::file_time_type::clock::now() -
                                 std::chrono::hours(1), ec);
     }
-    ~Env() { fs::remove_all(g_base); }
+    ~Env() {
+        // Non-throwing overload, and it matters on Windows. claimedSlot()
+        // deliberately leaks the slot lock handle for the process lifetime;
+        // there that is an exclusive CreateFileA handle, which BLOCKS deletion
+        // of the file. The throwing overload then raises filesystem_error out
+        // of a static destructor — std::terminate, and a non-zero exit that
+        // ctest reports as a failure even though every test passed. POSIX
+        // unlinks open files happily, so this only ever surfaced on Windows.
+        // A few leftover files in the temp directory are harmless.
+        std::error_code ec;
+        fs::remove_all(g_base, ec);
+    }
 } g_env;
 
 } // namespace

--- a/tests/test_reload_edit.cpp
+++ b/tests/test_reload_edit.cpp
@@ -46,6 +46,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include "test_tmp_path.h"
 
 namespace {
 
@@ -195,7 +196,7 @@ TEST(ReloadEdit, FilletSurvivesRealFileRoundTrip) {
     ASSERT_FALSE(st.params.empty()) << "fillet must serialise params to save";
 
     // 3. Save to a temp file, then load it back into a fresh doc/history.
-    const std::string path = "/tmp/mtz_fillet_roundtrip.materializr";
+    const std::string path = mzrtest::tmpPath("mtz_fillet_roundtrip.materializr");
     ASSERT_TRUE(ProjectIO::save(path, src, &hist).success);
 
     Document doc;
@@ -292,7 +293,7 @@ TEST(ReloadEdit, MoveHoleSurvivesRealFileRoundTrip) {
     hist.steps     = {st};
     ASSERT_FALSE(st.params.empty()) << "move-hole must serialise params to save";
 
-    const std::string path = "/tmp/mtz_movehole_roundtrip.materializr";
+    const std::string path = mzrtest::tmpPath("mtz_movehole_roundtrip.materializr");
     ASSERT_TRUE(ProjectIO::save(path, src, &hist).success);
     Document doc;
     ProjectHistory loaded;

--- a/tests/test_sketch_dimension.cpp
+++ b/tests/test_sketch_dimension.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #include <glm/glm.hpp>
 #include <cmath>
+#include "test_tmp_path.h"
 
 using materializr::Constraint;
 using materializr::ConstraintType;
@@ -379,10 +380,12 @@ using materializr::ProjectIO;
 namespace {
 
 std::string tmpProjectPath(const char* name) {
-    const char* t = std::getenv("TMPDIR");
-    std::string dir = t ? t : "/tmp";
-    if (!dir.empty() && dir.back() != '/') dir += '/';
-    return dir + name;
+    // temp_directory_path() honours TMPDIR on POSIX and TEMP/TMP on Windows.
+    // The previous "/tmp" fallback was an unwritable path on Windows, so
+    // ProjectIO::save failed and the ASSERT_TRUE(...success) below reported it
+    // as a persistence bug (DimensionPersistence.KLineRoundTripsTypeAndLabelOffsets,
+    // the first failure Windows CI ever caught).
+    return mzrtest::tmpPath(name);
 }
 
 } // namespace

--- a/tests/test_svg_roundtrip.cpp
+++ b/tests/test_svg_roundtrip.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 #include <cstdio>
 #include <memory>
+#include "test_tmp_path.h"
 
 using materializr::Sketch;
 using materializr::SvgExport;
@@ -41,7 +42,7 @@ TEST(SvgRoundTrip, ClosedLineLoopStaysOneClosedLoop) {
     for (int i = 0; i < 8; ++i) pid[i] = sk.addPoint({V[i][0], V[i][1]});
     for (int i = 0; i < 8; ++i) sk.addLine(pid[i], pid[(i + 1) % 8]);
 
-    const std::string path = "/tmp/mtz_svg_rt_loop.svg";
+    const std::string path = mzrtest::tmpPath("mtz_svg_rt_loop.svg");
     auto res = SvgExport::exportSketch(path, sk);
     ASSERT_TRUE(res.success) << res.errorMessage;
     EXPECT_EQ(res.curveCount, 1) << "one connected loop must export as ONE path";
@@ -69,7 +70,7 @@ TEST(SvgRoundTrip, CircleComesBackAsNativeCircle) {
     int c = sk.addPoint({10.0f, 10.0f});
     sk.addCircle(c, 7.0);
 
-    const std::string path = "/tmp/mtz_svg_rt_circle.svg";
+    const std::string path = mzrtest::tmpPath("mtz_svg_rt_circle.svg");
     auto res = SvgExport::exportSketch(path, sk);
     ASSERT_TRUE(res.success) << res.errorMessage;
 
@@ -100,7 +101,7 @@ TEST(SvgRoundTrip, LineArcProfileStaysClosed) {
     sk.addLine(p3, p4);
     sk.addLine(p4, p0);
 
-    const std::string path = "/tmp/mtz_svg_rt_arc.svg";
+    const std::string path = mzrtest::tmpPath("mtz_svg_rt_arc.svg");
     auto res = SvgExport::exportSketch(path, sk);
     ASSERT_TRUE(res.success) << res.errorMessage;
     EXPECT_EQ(res.curveCount, 1) << "lines + arc sharing endpoints = ONE path";
@@ -131,7 +132,7 @@ TEST(SvgRoundTrip, SplineSurvives) {
     ids.push_back(sk.addPoint({20, 4}));
     sk.addSpline(ids);
 
-    const std::string path = "/tmp/mtz_svg_rt_spline.svg";
+    const std::string path = mzrtest::tmpPath("mtz_svg_rt_spline.svg");
     auto res = SvgExport::exportSketch(path, sk);
     ASSERT_TRUE(res.success) << res.errorMessage;
 

--- a/tests/test_tmp_path.h
+++ b/tests/test_tmp_path.h
@@ -1,0 +1,40 @@
+#pragma once
+//
+// Portable scratch paths for tests.
+//
+// Several suites hardcoded "/tmp/...", which is fine on Linux and macOS and
+// simply does not exist on Windows — the file open fails and the surrounding
+// ASSERT_TRUE(res.success) fires, so the test reports a product bug that is
+// really just an unwritable path. std::filesystem::temp_directory_path() picks
+// the right directory on all three (honouring TMPDIR on POSIX and
+// TEMP/TMP/USERPROFILE on Windows), so tests use these helpers instead.
+
+#include <filesystem>
+#include <string>
+
+namespace mzrtest {
+
+// Temp directory as a string, WITHOUT a trailing separator.
+inline std::string tmpDir() {
+    std::error_code ec;
+    std::filesystem::path p = std::filesystem::temp_directory_path(ec);
+    if (ec || p.empty()) p = std::filesystem::current_path(ec); // last resort
+    return p.string();
+}
+
+// A path to `name` inside the temp directory, using the platform's separator.
+inline std::string tmpPath(const std::string& name) {
+    return (std::filesystem::path(tmpDir()) / name).string();
+}
+
+// A subdirectory inside the temp directory, created if absent. Returns its path
+// without a trailing separator. Replaces `std::system("mkdir -p /tmp/...")`,
+// which relied on a POSIX shell as well as a POSIX path.
+inline std::string tmpSubdir(const std::string& name) {
+    std::filesystem::path p = std::filesystem::path(tmpDir()) / name;
+    std::error_code ec;
+    std::filesystem::create_directories(p, ec);
+    return p.string();
+}
+
+} // namespace mzrtest

--- a/tests/test_topo_boolean_gen.cpp
+++ b/tests/test_topo_boolean_gen.cpp
@@ -22,6 +22,7 @@
 #include <gp_Pln.hxx>
 #include <cmath>
 #include <memory>
+#include "test_tmp_path.h"
 
 using materializr::Sketch;
 using namespace materializr;
@@ -333,7 +334,7 @@ TEST(TopoBooleanGen, ReloadedSeamFilletFollowsEdit) {
     st.params = fil.serializeParams();
     st.changed = {{bodyA, doc.getBody(bodyA)}};
     hist.steps = {st};
-    const std::string path = "/tmp/mtz_seam_roundtrip.materializr";
+    const std::string path = mzrtest::tmpPath("mtz_seam_roundtrip.materializr");
     ASSERT_TRUE(ProjectIO::save(path, doc, &hist).success);
     Document scratch;
     ProjectHistory loaded;

--- a/tests/test_unfold.cpp
+++ b/tests/test_unfold.cpp
@@ -29,6 +29,7 @@
 #include <cstdlib>
 #include <string>
 #include <vector>
+#include "test_tmp_path.h"
 
 using namespace materializr;
 
@@ -478,7 +479,7 @@ TEST(Unfold, DISABLED_DiagConformal) {
         cases.push_back({"loft", facesOf(loft.Shape())});
     }
 
-    std::system("mkdir -p /tmp/cdiag");
+    const std::string diagDir = mzrtest::tmpSubdir("cdiag");
     std::fprintf(stderr, "\n%-11s %-12s ok pcs  dist%%  curv  loops  pts  selfX\n", "shape", "method");
     for (auto& c : cases) {
         if (c.faces.empty()) { std::fprintf(stderr, "%-11s (no faces)\n", c.name.c_str()); continue; }
@@ -488,7 +489,7 @@ TEST(Unfold, DISABLED_DiagConformal) {
             std::fprintf(stderr, "%-11s %-12s %d  %d  %6.1f %6.1f %5zu %5zu %6d\n",
                          c.name.c_str(), m, fp.ok ? 1 : 0, fp.piecesPlaced, fp.distortionPct,
                          fp.curvatureDeg, loops, pts, countSelfIntersections(fp));
-            dumpJson("/tmp/cdiag/" + c.name + "-" + m + ".json", fp);
+            dumpJson(diagDir + "/" + c.name + "-" + m + ".json", fp);
         };
         report("conformal",   unfoldConformal(c.faces, 10.0, 1.0));
         report("developable", unfoldDevelopableNet(c.faces, 10.0, 1.0));


### PR DESCRIPTION
Supersedes #70 — same branch, but opened from this repo rather than the
`TechHQUSA` fork so the Windows job can use the vcpkg binary cache. #70 pays a
~3.5 h penalty per round compiling OpenCASCADE from source, because a fork PR's
token cannot authenticate to this org's NuGet feed. Please close #70 in favour
of this one.

## What this does

No workflow had a `pull_request` trigger, so **nothing was built or tested until
after a branch had already merged to `main`** — and `macos.yml` was the only job
running `ctest` at all. A contribution's first automated verification happened
downstream of the merge that could break `main`.

- All three workflows now trigger on `pull_request` to `main`, reusing the same
  `paths-ignore` filters as their `push` trigger.
- `windows.yml` builds with `BUILD_TESTS=ON` and runs `ctest`. It passed
  `BUILD_TESTS=OFF` before, so the suite had never run on Windows. `ctest` needs
  `-C Release` here: the Visual Studio generator is multi-config, and without it
  ctest finds no tests and exits 0 — a green check that verified nothing.
- `windows.yml` gains a `concurrency` group so a new commit on a PR cancels the
  in-flight run; the other two already had one.

Plus the test-side changes needed to make the suite actually pass on Windows:

- **`tests/test_tmp_path.h`** — seven suites wrote to hardcoded `/tmp/...`, which
  cannot work on Windows: the open fails and the surrounding
  `ASSERT_TRUE(res.success)` fires, reporting a product bug that is really an
  unwritable path. Now `std::filesystem::temp_directory_path()`, which resolves
  correctly on all three platforms. `test_unfold` also shelled out to
  `std::system("mkdir -p /tmp/cdiag")` — POSIX shell as well as POSIX path — now
  `create_directories`.
- **`test_recovery`'s destructor no longer throws.** `claimedSlot()` deliberately
  leaks the slot lock handle for the process lifetime; on Windows that is an
  exclusive `CreateFileA` handle, and Windows blocks deletion of a file with an
  open handle, so `fs::remove_all(g_base)` raised `filesystem_error` out of a
  static destructor — `std::terminate`, non-zero exit, ctest failure with every
  test green. Uses the non-throwing `error_code` overload.

Two adjustments the PR trigger forces:

- **The vcpkg NuGet cache is read-only on pull requests.** A fork PR gets a
  read-only `GITHUB_TOKEN`, and a PR build should not be able to write the cache
  that later `main` builds consume.
- **The NSIS step takes `APPVERSION` through the environment** instead of
  interpolating `${{ github.ref_name }}` into the command line. Actions expands
  `${{ }}` textually before pwsh parses it, and ref names may legally contain
  `"`, `;`, `$` and backticks — enough to append a statement in a job holding
  `contents: write` and `packages: write`.

## How it was tested

Green on all four checks on #70 at `55709a9`, including **the first Windows
`ctest` run in this project's history**:

```
AppImage (aarch64): pass
AppImage (x86_64):  pass
macOS (arm64):      pass
windows:            pass     100% tests passed out of 50
```

This branch is that work rebased onto `dd5c182` (conflict-free). Locally on
macOS at `43b7540`: **51/51 pass**. CI on this PR re-verifies on the synced
commit — and should complete in minutes rather than hours, with the cache.

Getting there took five rounds, and each found a real defect that `main` could
not see:

1. Four targets had never compiled on Windows (`sys/wait.h`, `setenv`) — since
   fixed on `main` by d678636, so those commits were dropped from this branch.
2. A transient upstream 504 fetching freetype sources.
3. First `ctest` run: 46/47. The one failure was a **real Windows defect in code
   already merged to `main`** via #69 — a `/tmp` fallback resolving to an
   unwritable path.
4. A POSIX-only assumption in the newly-ported `test_recovery` — since solved
   better on `main` using the new `projectRecoveryOrphanCount()` API, so that
   commit was dropped too.
5. The throwing static destructor above.

## Known gap

**Linux still builds without tests.** The AppImage image compiles OCCT from
source, so a test job there costs ~30 min per run. It verifies the tree
compiles on Linux; macOS and Windows carry the suite. A separate lightweight
Linux test job using distro OCCT would close it, but it would then test against
a different OCCT version than the one shipped — which seemed worse than the
status quo.
