### PR TITLE
build: pin ImGui to a commit and verify appimagetool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,11 +66,22 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(glm)
 
-# ImGui (docking branch)
+# ImGui (docking branch), pinned to a commit.
+#
+# GIT_TAG was `docking` — a BRANCH HEAD, so every configure resolved to whatever
+# that branch pointed at that day. ImGui is the entire UI and input layer,
+# compiled straight into the shipped binary, so an upstream force-push or a
+# merged malicious PR would land in the next release with no review step; and
+# two builds of the same Materializr tag could ship different ImGui, which makes
+# a release impossible to reproduce.
+#
+# This SHA is v1.92.9-docking-2, the commit the tree is already building and
+# testing against — pinning current reality, not a version change. Bump it
+# deliberately; keep it in step with android/app/jni/src/CMakeLists.txt.
 FetchContent_Declare(
     imgui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
-    GIT_TAG        docking
+    GIT_TAG        81cfcb8c1fed1e4dac8bcdc059ce811c17b6194c # v1.92.9-docking-2
 )
 FetchContent_MakeAvailable(imgui)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,28 @@ RUN mkdir -p build && cd build \
         -DMZR_OCCT_PREFIX=/usr/local \
     && make -j$(nproc)
 
-# Download appimagetool
+# appimagetool — pinned tag + per-arch sha256, same treatment as OCCT above.
+#
+# This was `continuous`: a rolling tag upstream force-updates, downloaded with
+# no integrity check and then EXECUTED to package every shipped Linux release.
+# Anyone able to publish to that tag (or interpose on the download) could inject
+# into the AppImage users install, and nothing in the pipeline would notice.
+#
+# 1.9.1 is the current stable release, and is byte-identical to what
+# `continuous` serves today — so this pins the behaviour we already have rather
+# than changing versions. Bumping is then a deliberate, reviewable diff.
+ARG APPIMAGETOOL_VERSION=1.9.1
+ARG APPIMAGETOOL_SHA256_X86_64=ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0
+ARG APPIMAGETOOL_SHA256_AARCH64=f0837e7448a0c1e4e650a93bb3e85802546e60654ef287576f46c71c126a9158
 RUN ARCH=$(uname -m) \
-    && wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage" \
+    && case "$ARCH" in \
+         x86_64)  AIT_SHA="$APPIMAGETOOL_SHA256_X86_64" ;; \
+         aarch64) AIT_SHA="$APPIMAGETOOL_SHA256_AARCH64" ;; \
+         *) echo "no pinned appimagetool checksum for arch $ARCH" >&2; exit 1 ;; \
+       esac \
+    && wget -q "https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-${ARCH}.AppImage" \
         -O /usr/local/bin/appimagetool \
+    && echo "${AIT_SHA}  /usr/local/bin/appimagetool" | sha256sum -c - \
     && chmod +x /usr/local/bin/appimagetool
 
 # ─── Create AppDir structure ────────────────────────────────────────────────

--- a/android/app/jni/src/CMakeLists.txt
+++ b/android/app/jni/src/CMakeLists.txt
@@ -30,7 +30,11 @@ set(OCCT_LIB "${OCCT_ROOT}/lib")
 
 # ── ImGui (docking) + GLM, same versions as the desktop build ────────────────
 include(FetchContent)
-FetchContent_Declare(imgui GIT_REPOSITORY https://github.com/ocornut/imgui.git GIT_TAG docking)
+# Pinned to a commit, not the `docking` branch head — see the rationale in the
+# top-level CMakeLists.txt. Keep this SHA in step with that one so desktop and
+# Android build the same ImGui.
+FetchContent_Declare(imgui GIT_REPOSITORY https://github.com/ocornut/imgui.git
+                     GIT_TAG 81cfcb8c1fed1e4dac8bcdc059ce811c17b6194c) # v1.92.9-docking-2
 FetchContent_MakeAvailable(imgui)
 FetchContent_Declare(glm GIT_REPOSITORY https://github.com/g-truc/glm.git GIT_TAG 1.0.1)
 FetchContent_MakeAvailable(glm)


### PR DESCRIPTION
Two build inputs were unpinned, and both reach the shipped binary. Neither is a
version change — both pin the behaviour already in use, so the diff should be a
no-op at runtime.

## ImGui was tracking a branch head

`GIT_TAG docking` is a **branch**, so every configure resolved to whatever that
branch pointed at that day. ImGui is the entire UI and input layer, compiled
straight into the binary — an upstream force-push or a merged malicious PR would
land in the next release with no review step in between. It also makes releases
irreproducible: two builds of the same Materializr tag could ship different
ImGui.

Pinned to `81cfcb8c1fed1e4dac8bcdc059ce811c17b6194c` (`v1.92.9-docking-2`) in
both `CMakeLists.txt` and `android/app/jni/src/CMakeLists.txt` — the commit the
tree is already building and testing against.

## appimagetool was downloaded unverified, then executed

It came from the rolling `continuous` tag with no integrity check, and it is the
tool that **packages every shipped Linux release**. Anyone able to publish to
that tag, or interpose on the download, could inject into the AppImage users
install, and nothing in the pipeline would notice. The OCCT tarball twenty lines
above in the same Dockerfile has been sha256-pinned all along.

Now pinned to release `1.9.1` with a per-arch sha256, checked the same way, and
an unknown architecture fails loudly rather than silently skipping verification:

```
x86_64   ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0
aarch64  f0837e7448a0c1e4e650a93bb3e85802546e60654ef287576f46c71c126a9158
```

`1.9.1` is byte-identical to what `continuous` serves today (15092216 and
14678536 bytes), so this pins what is already in use.

## How it was tested

- Clean configure from an empty build dir fetches **exactly** `81cfcb8c1`
  (`git describe` → `v1.92.9-docking-2-g81cfcb8c1`), confirming the pin resolves
  rather than silently falling back.
- From-scratch build + `ctest` on macOS: **54/54 pass**.
- **The appimagetool change is not verified locally** — it needs the full Docker
  image with its from-source OCCT build. The Linux AppImage job exercises it; if
  the checksum or the arch `case` is wrong, that job fails loudly, which is the
  intended behaviour.

## Note

Bumping either dependency is now a deliberate, reviewable diff rather than a
silent change between builds. The two ImGui SHAs must be kept in step — desktop
and Android should compile the same ImGui.
