### PR TITLE
fix: latticeAnchor doesn't compile on MSVC — `near` is a macro

### DIFF
--- a/src/modeling/Sketch.cpp
+++ b/src/modeling/Sketch.cpp
@@ -59,14 +59,19 @@ const gp_Pln& Sketch::getPlane() const {
     return m_plane;
 }
 
-gp_Pnt Sketch::latticeAnchor(const gp_Pln& plane, const gp_Pnt& near,
+// NB: the point parameter is `nearPt`, not `near`. <windef.h> still defines
+// `near` (and `far`) as empty macros from the 16-bit memory-model days, so on
+// MSVC a parameter called `near` is erased: `return near;` becomes `return ;`
+// and `gp_Vec rel(o, near)` becomes `gp_Vec rel(o, )`. The build breaks with a
+// pile of errors that never mention the macro.
+gp_Pnt Sketch::latticeAnchor(const gp_Pln& plane, const gp_Pnt& nearPt,
                              double step) {
-    if (step <= 0.0) return near;
+    if (step <= 0.0) return nearPt;
     const gp_Ax3& ax = plane.Position();
     const gp_Pnt o = ax.Location();
     const gp_Dir xd = ax.XDirection();
     const gp_Dir yd = ax.YDirection();
-    const gp_Vec rel(o, near);
+    const gp_Vec rel(o, nearPt);
     const double u = std::round(rel.Dot(gp_Vec(xd)) / step) * step;
     const double v = std::round(rel.Dot(gp_Vec(yd)) / step) * step;
     return gp_Pnt(o.X() + u * xd.X() + v * yd.X(),

--- a/src/modeling/Sketch.h
+++ b/src/modeling/Sketch.h
@@ -125,7 +125,9 @@ public:
     // arbitrary fraction of a cell in-plane. Anything that has to agree with
     // where clicks land — above all the grid the viewport DRAWS — must round
     // here rather than roll its own.
-    static gp_Pnt latticeAnchor(const gp_Pln& plane, const gp_Pnt& near,
+    // `nearPt`, not `near` — <windef.h> defines `near` as an empty macro, which
+    // silently erases the parameter on MSVC. See the definition in Sketch.cpp.
+    static gp_Pnt latticeAnchor(const gp_Pln& plane, const gp_Pnt& nearPt,
                                 double step);
 
     // Element removal


### PR DESCRIPTION
**`main` currently fails to build on Windows.** This unbreaks it.

```
Sketch.cpp(64,22): error C2561: 'latticeAnchor': function must return a value
Sketch.cpp(69,29): error C2059: syntax error: ')'
Sketch.cpp(70,33): error C2065: 'rel': undeclared identifier
Sketch.cpp(70,18): error C2737: 'u': const object must be initialized
```

None of those mentions the actual cause. `<windef.h>` still defines `near` and
`far` as **empty macros**, left over from 16-bit memory models, so a parameter
named `near` is erased by the preprocessor before the compiler ever sees it:

```cpp
return near;                 // -> return ;            C2561
const gp_Vec rel(o, near);   // -> gp_Vec rel(o, );    C2059
```

`rel`, `u` and `v` cascade from there. Renamed to `nearPt` in both the
declaration and the definition, with a short note at each site so it doesn't
get reintroduced.

## How this got in

Introduced by `2474035` ("sketch: clicks land on the snap grid"). It went
unnoticed because **Windows had no compile or test gate on pull requests** until
#73 merged an hour ago — the very next PR's CI (#75) caught it immediately.
That's the new gate doing precisely what it was added for.

## How it was tested

- macOS: clean build, **54/54 tests pass**.
- Swept `src/` for any other bare `near`/`far` identifier — none; the remaining
  matches are prose inside strings and comments.
- Windows is verified by this PR's own CI, which is the only way to check it.

## Note

Worth merging ahead of #75 — that PR is green on macOS and both Linux arches and
is only red because of this pre-existing breakage.
