### PR TITLE
fix: saving while drawing a sketch silently discarded it

### DIFF
--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -3283,7 +3283,32 @@ std::string Application::projectDisplayName() const {
     return pn;
 }
 
+// A save taken while a sketch is being drawn must not lose that sketch.
+//
+// m_activeSketch is a live shared_ptr the Document does not know about until
+// sketch mode ENDS (the registration in exitSketchMode). Saving straight from
+// sketch mode therefore serialised SKETCH_COUNT 0 — the geometry was simply
+// absent from the file — and the accompanying SketchEditOp step serialised with
+// no params, because SketchEditOp::serializeWithDocument resolves its target via
+// Document::findSketchId, which cannot resolve an unregistered pointer. The
+// result reloaded as a frozen ReplayOp that reproduces nothing. Drawing a circle
+// and pressing Ctrl+S was enough to lose it.
+//
+// Registering here rather than force-finishing the sketch is deliberate: a save
+// should never change what the user is editing, and they stay in sketch mode.
+// exitSketchMode stays correct afterwards — its add is guarded on
+// m_activeSketchId < 0, so it will not add the same sketch twice, and its
+// "existing sketch emptied during this edit" branch still removes it.
+void Application::flushActiveSketchToDocument() {
+    if (!m_document || !m_activeSketch) return;
+    if (m_activeSketchId >= 0) return;                // already in the Document
+    if (m_activeSketch->elementCount() == 0) return;  // nothing worth keeping
+    m_activeSketchId = m_document->addSketch(m_activeSketch);
+    markDirty();
+}
+
 void Application::saveProject() {
+    flushActiveSketchToDocument();
     // Seed the picker with the CURRENT project's name (a resave keeps its
     // name instead of silently reverting to "project.materializr").
     std::string suggest = m_currentProjectName;
@@ -3381,6 +3406,7 @@ void Application::saveProject() {
 }
 
 void Application::saveProjectQuick() {
+    flushActiveSketchToDocument();
     // An explicit save expresses "keep what's committed" — captureProjectHistory
     // cancels any live preview first, so a mid-preview save can't persist the
     // preview body and its phantom history step. (Historically that leaked and

--- a/src/app/Application.h
+++ b/src/app/Application.h
@@ -235,6 +235,9 @@ private:
     void saveProject();
     std::string projectDisplayName() const;    // name or basename or "New project"         // Save dialog (Save As behavior)
     void saveProjectQuick();    // Save to current path if known, else falls through to saveProject
+    // Register the sketch currently being drawn into the Document so a save
+    // taken mid-sketch actually contains it. Idempotent; see the definition.
+    void flushActiveSketchToDocument();
     // Render the "home view" of the project (visible bodies only — no
     // sketches, planes, axes, grid or overlays; reset isometric camera,
     // zoom-fit) into an offscreen 512px square and PNG-encode it. Embedded


### PR DESCRIPTION
**Data loss.** Draw a circle, press Ctrl+S without leaving sketch mode, and the
circle is gone from the file. No warning, no error. Reported on macOS; the cause
is platform-independent.

## What the file showed

```
SKETCH_COUNT 0
HISTORY_COUNT 1
  TYPE sketchedit
  DESC "Circle Ø420.0 mm"     <- history knows you drew it
  CHANGED_COUNT 0             <- but the step carries no params
```

234 bytes. The geometry was never written, so loading it correctly showed
nothing — this looked like a load bug and wasn't.

## Cause

`m_activeSketch` is a live `shared_ptr` the `Document` does not know about until
sketch mode **ends** — the registration at the end of `exitSketchMode`. Saving
from inside sketch mode serialises a `Document` with no sketches.

The empty history step has the same root: `SketchEditOp::serializeWithDocument`
resolves its target via `Document::findSketchId`, which cannot resolve an
unregistered pointer, so it emits no params and the step reloads as a frozen
`ReplayOp` that reproduces nothing. The existing comment there already warns
about exactly this failure mode.

## Fix

`flushActiveSketchToDocument()` registers the sketch before serialising, called
from both `saveProject()` and `saveProjectQuick()`.

Registering rather than force-finishing the sketch is deliberate — a save should
not change what the user is editing, so they stay in sketch mode afterwards. It
cannot double-add: it returns early once `m_activeSketchId` is set, which is the
same guard `exitSketchMode`'s own add uses, and that path's "existing sketch
emptied during this edit" branch still behaves correctly.

## How it was tested

End to end on the running app — draw a circle, Ctrl+S from **inside** sketch
mode:

| | before | after |
|---|---|---|
| file size | 234 B | 9.8 KB (21 KB uncompressed) |
| `SKETCH_COUNT` | **0** | **1** |
| `CIRCLE_COUNT` | — | 2 |

Full suite: **54/54**.

## No automated test, and why

The fix lives in `Application`, which needs a GL context, so it sits outside what
`materializr_core` links — the test suite cannot reach it. Covering it properly
means extracting the flush behind a testable seam. Worth doing, but I did not
want to fold a refactor into a data-loss fix.

Related: this is the second bug in as many days that only a real run could catch
(the first being the MSVC `near` macro in #76). A headless "Application-lite"
seam would make both testable.
