### PR TITLE
fix: define mobileLastOpenWasFallback() on iOS (arm64 link failure)

### DIFF
--- a/src/ios_files.mm
+++ b/src/ios_files.mm
@@ -241,6 +241,10 @@ std::string mobileOpenUri(const std::string& uri) {
     return ok ? tmp : std::string{};
 }
 
+// mobileOpenUri() above never substitutes a backup copy — it returns the real
+// document or fails — so an open here is never "via fallback".
+bool mobileLastOpenWasFallback() { return false; }
+
 // SDL's iOS backend raises/dismisses the system keyboard itself from
 // SDL_StartTextInput/SDL_StopTextInput — the Android IME workaround isn't
 // needed here.


### PR DESCRIPTION
mobile_files.h declares mobileLastOpenWasFallback() for all MZ_MOBILE builds and Application.cpp calls it, but only android_files.cpp defined it — the iOS link failed with an undefined symbol. iOS's mobileOpenUri() never substitutes a backup copy (it resolves the security-scoped bookmark or fails outright), so the correct iOS answer is always false.

## What this does

Adds a missing function stub

## How it was tested

OSX built and tested (Iphone) only issue.

## Checklist

- [-] Builds on desktop (`cmake --build build-desktop`) and tests pass (`ctest`)
- [-] If it touches Android, it builds there too — and desktop behavior is unchanged
- [-] New user-facing **features live in a plugin** (`src/plugins/`), not bolted into core
- [-] Touch-specific behavior is gated on `materializr::touchMode()`, not `#if __ANDROID__`
- [ x] Code matches the style of the surrounding files
