### PR TITLE
app: Crash-recovery sidecar skips full undo history, keeping the write fast

### DIFF
--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -7177,9 +7177,21 @@ void Application::writeProjectRecoveryIfDue() {
     // cut. Skip this tick - the body is mid-recompute anyway, and the next
     // tick lands right after the recut does.
     if (!m_threadRecuts.empty()) return;
-    ProjectHistory hist = captureProjectHistory(/*cancelPreviews=*/false);
-    if (materializr::writeProjectRecovery(*m_document, &hist, m_currentProjectPath,
-                                          bodies, curStep + 1,
+    // Crash recovery only needs to restore CURRENT geometry, not the full undo
+    // stack - so skip captureProjectHistory() entirely here (it walks every
+    // step, re-serializing each op's params) and pass no history to the
+    // writer. History blocks are the dominant cost on a project with many
+    // baked steps (each carries a full per-body BRep snapshot, not a delta -
+    // see ProjectIO::save's HISTORY_COUNT block), so this is what actually
+    // keeps a recovery write fast regardless of how much undo history the
+    // session has accumulated. The real Ctrl+S / File > Save path is
+    // untouched and keeps writing full history as always; only the
+    // best-effort crash sidecar trades "restore my undo stack after a crash"
+    // for "restore my current work, fast, without stuttering the editor to
+    // get there." stepCount is reported as 0 to match what actually loads.
+    if (materializr::writeProjectRecovery(*m_document, /*history=*/nullptr,
+                                          m_currentProjectPath,
+                                          bodies, /*stepCount=*/0,
                                           currentSession().recoveryIndex)) {
         m_lastRecoveryWrite = now;
         m_lastRecoveryStep = curStep;
@@ -7195,11 +7207,10 @@ void Application::writeSessionRecoveryNow() {
     if (!isDirty() || !m_document) return;
     if (m_history && m_history->canRedo()) return;   // same below-tip guard
     if (!m_threadRecuts.empty()) return;
-    ProjectHistory hist = captureProjectHistory(/*cancelPreviews=*/false);
+    // See writeProjectRecoveryIfDue: no history in the crash-recovery sidecar.
     materializr::writeProjectRecovery(
-        *m_document, &hist, m_currentProjectPath,
-        m_document->bodyCount(),
-        (m_history ? m_history->currentStep() : -1) + 1,
+        *m_document, /*history=*/nullptr, m_currentProjectPath,
+        m_document->bodyCount(), /*stepCount=*/0,
         currentSession().recoveryIndex);
 }
 


### PR DESCRIPTION
## Summary

Lower-risk mitigation for a reported slowness/stutter issue, while a more thorough fix (making the crash-recovery write itself asynchronous) is investigated separately.

The crash-recovery writer already debounces (fires ~5s after edits settle, per #48) and uses fastest compression, but still re-serializes and re-gzips the **entire undo history** on every write: `captureProjectHistory()` walks every step and re-serializes each op's params, and `ProjectIO::save()` writes a full per-body BRep snapshot for every body touched by every step (not a delta). On a project with many baked history steps and an imported STL, write cost scales with total historical churn, not current complexity, and can make even a "fastest compression" write take multiple seconds.

Crash recovery only needs to restore current geometry — losing the undo stack on a crash-recovery restore is an acceptable, honestly-labeled tradeoff (`stepCount` is now reported as `0` in the recovery meta file to match what actually loads) in exchange for a write that no longer scales with history size. The real Ctrl+S / File > Save path is completely untouched and keeps writing full history as always; this only affects the best-effort background crash-recovery sidecar.

**Important caveat:** this does not fully explain a separate reported freeze during active sketch editing (placing a line, using Trim) — `writeProjectRecoveryIfDue()` already bails out early while `m_inSketchMode` is true, so it cannot be the direct cause of a stutter occurring during those exact actions. That's still under investigation. This fix is a real, independently worthwhile reduction in worst-case recovery-write cost regardless (e.g., it'll help whenever the write does land, such as right after exiting a sketch on a project with a lot of accumulated history).

**Follow-up needed:** the write is still synchronous on the main thread. A proper fix would move it to a background thread, but that's a bigger, higher-risk change (this app has had real recovery/save data-integrity bugs before) that deserves its own dedicated design/review rather than being bundled here.

## Test plan
- [x] Full `ctest` suite on the VM: 113/113 passed
- [x] Clean VM build, no new warnings
- [ ] CI green on Linux/macOS/Windows (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)