### PR TITLE
app: Don't let a recovery orphan overwrite an already-occupied active tab

### DIFF
--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -7279,17 +7279,25 @@ void Application::restoreProjectRecoveryNow() {
     if (paths.empty()) return;
 
     int restored = 0, failed = 0;
+    bool firstLandedInNewTab = false;
     size_t firstTab = m_activeSession;   // where the newest snapshot lands
     for (size_t i = 0; i < paths.size(); ++i) {
         const std::string& recPath = paths[i];
         materializr::ProjectRecoveryMeta meta;
         materializr::readProjectRecoveryMetaAt(recPath, meta);
-        // Each snapshot after the first gets its own tab. A refused switch
-        // can't happen here (nothing is mid-sketch at startup), but honour it
-        // anyway rather than restoring into the wrong tab.
-        if (restored > 0) {
+        // Each snapshot after the first gets its own tab. The first one does
+        // too, UNLESS the active tab is an empty scratch workspace: this
+        // restore can run at any point in a live session, not just at a
+        // fresh launch, and the active tab may hold real, unrelated,
+        // unsaved work - an orphan from a completely different dead
+        // instance must never silently overwrite it (Steve's report: an
+        // orphan snapshot replaced an open, in-progress project). A refused
+        // switch can't happen at true startup, but honour it anyway rather
+        // than restoring into the wrong tab.
+        if (restored > 0 || !activeSessionIsScratch()) {
             const size_t idx = createSession();
             if (!switchToSession(idx)) { closeSession(idx); ++failed; continue; }
+            if (restored == 0) { firstTab = idx; firstLandedInNewTab = true; }
         }
         // Load through the normal project loader (rebuilds bodies + editable
         // history). loadProjectAt sets m_currentProjectPath to the sidecar and
@@ -7317,12 +7325,17 @@ void Application::restoreProjectRecoveryNow() {
                      meta.bodyCount, meta.stepCount, m_activeSession);
     }
     // Land on the tab the PROMPT described (the newest snapshot), not
-    // whichever one happened to load last.
-    if (restored > 1 && firstTab < m_sessions.size()) switchToSession(firstTab);
+    // whichever one happened to load last - including when that snapshot
+    // got redirected to a fresh tab above because the active one wasn't
+    // scratch.
+    if ((restored > 1 || firstLandedInNewTab) && firstTab < m_sessions.size())
+        switchToSession(firstTab);
     materializr::clearProjectRecoveryCandidate();  // whatever is left of it
     saveAppSettings();                             // fix lastProjectPath off the sidecar
     if (restored > 1)
         showToast("Recovered " + std::to_string(restored) + " projects.");
+    else if (restored == 1 && firstLandedInNewTab)
+        showToast("Recovered unsaved work into a new tab.");
     if (failed > 0)
         showToast(std::to_string(failed) + " recovered project(s) "
                   "couldn't be reopened.");


### PR DESCRIPTION
## Summary

Reported: an orphaned "hole plug.mzr" recovery snapshot replaced an open "rear cover.mzr" tab, and "hole plug.mzr" also ended up open in a duplicate tab.

Root cause: `restoreProjectRecoveryNow()` always loads the newest orphan snapshot into whatever tab is currently active - by explicit design, per its own comment ("goes first so it lands in the tab the user is already looking at"). That assumption only holds right after a fresh launch, where the active tab is empty. It breaks when restore runs against an already-populated, ongoing session: an orphan left behind by a **completely unrelated** dead instance (e.g. a second window used to test something else, killed rather than closed normally, which skips the normal recovery-file cleanup) silently overwrites a live tab's real, unsaved project.

Fix: check `activeSessionIsScratch()` (already used elsewhere for exactly this "don't clobber an occupied tab" guard) before landing the first/newest orphan in the active tab. If it's occupied, that orphan gets its own new tab too, same as every orphan after it - and the app switches to and reports that new tab so it's not silently invisible.

## Test plan
- [x] Full `ctest` suite on the VM: 113/113 passed
- [x] Clean VM build, no new warnings
- [ ] CI green on Linux/macOS/Windows (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)